### PR TITLE
[issue 26] - Enabling Operator provisioner desired channel configuration

### DIFF
--- a/.ci/openshift-ci/build-root/e2e-test.sh
+++ b/.ci/openshift-ci/build-root/e2e-test.sh
@@ -50,6 +50,7 @@ xtf.openshift.master.kubeconfig=${KUBECONFIG}
 intersmash.wildfly.operators.catalog_source=community-operators-wildfly-operator
 intersmash.wildfly.operators.index_image=quay.io/operatorhubio/catalog:latest
 intersmash.wildfly.operators.package_manifest=wildfly
+intersmash.wildfly.operators.channel=alpha
 EOL
 
 cat test.properties

--- a/.ci/openshift-ci/build-root/e2e-test.sh
+++ b/.ci/openshift-ci/build-root/e2e-test.sh
@@ -57,4 +57,4 @@ cat test.properties
 
 mkdir local-repo
 mvn clean install -Dmaven.repo.local=./local-repo -DskipTests
-mvn clean test -Dmaven.repo.local=./local-repo -pl testsuite/ -am
+mvn test -Dmaven.repo.local=./local-repo -pl testsuite/ -am

--- a/README.md
+++ b/README.md
@@ -426,9 +426,7 @@ is also used internally, properties are resolved as following: System Properties
 test.properties file > global-test.properties, see https://github.com/xtf-cz/xtf#configuration for more details on this.
 
 ### Configuration properties
-The following properties could be used to configure Intersmash. You can keep the defaults here for start.
-
-Intersmash properties:
+The following properties could be used to configure Intersmash:
 
 | Property                                         | Description                                                                         |
 |--------------------------------------------------|-------------------------------------------------------------------------------------|
@@ -446,25 +444,31 @@ Intersmash properties:
 | intersmash.wildfly.operators.catalog_source      | Wildfly custom catalog for Operator (must be in namespace openshift-marketplace)    |
 | intersmash.wildfly.operators.index_image         | Wildfly custom index image for Operator                                             |
 | intersmash.wildfly.operators.package_manifest    | Wildfly custom package manifest for Operator                                        |
+| intersmash.wildfly.operators.channel             | Wildfly desired channel for Operator                                                |
 | intersmash.infinispan.image                      | Infinispan image URL                                                                |
 | intersmash.infinispan.templates                  | URL where Infinispan OpenShift templates resides                                    |
 | intersmash.infinispan.operators.catalog_source   | Infinispan custom catalog for Operator (must be in namespace openshift-marketplace) |
 | intersmash.infinispan.operators.index_image      | Infinispan custom index image for Operator                                          |
 | intersmash.infinispan.operators.package_manifest | Infinispan custom package manifest for Operator                                     |
+| intersmash.infinispan.operators.channel          | Infinispan desired channel for Operator                                             |
 | intersmash.keycloak.image                        | Keycloak image URL                                                                  |
 | intersmash.keycloak.templates                    | URL where Keycloak OpenShift templates resides                                      |
 | intersmash.keycloak.operators.catalog_source     | Keycloak custom catalog for Operator (must be in namespace openshift-marketplace)   |
 | intersmash.keycloak.operators.index_image        | Keycloak custom index image for Operator                                            |
 | intersmash.keycloak.operators.package_manifest   | Keycloak custom package manifest for Operator                                       |
+| intersmash.keycloak.operators.channel            | Keycloak desired channel for Operator                                               |
 | intersmash.kafka.operators.catalog_source        | Kafka custom catalog for Operator (must be in namespace openshift-marketplace)      |
 | intersmash.kafka.operators.index_image           | Kafka custom index image for Operator                                               |
 | intersmash.kafka.operators.package_manifest      | Kafka custom package manifest for Operator                                          |
+| intersmash.kafka.operators.channel               | Kafka desired channel for Operator                                                  |
 | intersmash.activemq.operators.catalog_source     | ActiveMQ custom catalog for Operator (must be in namespace openshift-marketplace)   |
 | intersmash.activemq.operators.index_image        | ActiveMQ custom index image for Operators                                           |
 | intersmash.activemq.operators.package_manifest   | ActiveMQ custom package manifest for Operators                                      |
+| intersmash.activemq.operators.channel            | ActiveMQ desired channel for Operator                                               |
 | intersmash.hyperfoil.operators.catalog_source    | HyperFoil custom catalog for Operator (must be in namespace openshift-marketplace)  |
 | intersmash.hyperfoil.operators.index_image       | HyperFoil custom index image for Operators                                          |
 | intersmash.hyperfoil.operators.package_manifest  | HyperFoil custom package manifest for Operators                                     |
+| intersmash.hyperfoil.operators.channel           | HyperFoil desired channel for Operator                                              |
 | wildfly.feature-pack.location                    | Wildfly feature pack used by shared configurable deployments                        |
 | wildfly.ee-feature-pack.location                 | Wildfly EE feature pack used by shared configurable deployments                     |
 | wildfly.cloud-feature-pack.location              | Wildfly cloud feature pack used by shared configurable deployments                  |

--- a/global-test.properties
+++ b/global-test.properties
@@ -11,6 +11,3 @@ xtf.junit.prebuilder.synchronized=true
 
 # Bootable jar
 intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
-
-# WildFly
-intersmash.wildfly.operators.channel=alpha

--- a/global-test.properties
+++ b/global-test.properties
@@ -11,3 +11,6 @@ xtf.junit.prebuilder.synchronized=true
 
 # Bootable jar
 intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
+
+# WildFly
+intersmash.wildfly.operators.channel=alpha

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
@@ -37,40 +37,45 @@ public class IntersmashConfig {
 	// Custom Catalogs for operators
 	private static final String INFINISPAN_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.infinispan.operators.catalog_source";
 	private static final String INFINISPAN_OPERATOR_INDEX_IMAGE = "intersmash.infinispan.operators.index_image";
+	private static final String INFINISPAN_OPERATOR_CHANNEL = "intersmash.infinispan.operators.channel";
 	private static final String INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "intersmash.infinispan.operators.package_manifest";
 	private static final String COMMUNITY_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "infinispan";
 	private static final String PRODUCT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "datagrid";
 	private static final String DEFAULT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_INFINISPAN_OPERATOR_PACKAGE_MANIFEST;
 	private static final String KEYCLOAK_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.keycloak.operators.catalog_source";
 	private static final String KEYCLOAK_OPERATOR_INDEX_IMAGE = "intersmash.keycloak.operators.index_image";
+	private static final String KEYCLOAK_OPERATOR_CHANNEL = "intersmash.keycloak.operators.channel";
 	private static final String KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "intersmash.keycloak.operators.package_manifest";
 	private static final String COMMUNITY_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "keycloak-operator";
 	private static final String PRODUCT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "rhsso-operator";
 	private static final String DEFAULT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST;
 	private static final String WILDFLY_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.wildfly.operators.catalog_source";
 	private static final String WILDFLY_OPERATOR_INDEX_IMAGE = "intersmash.wildfly.operators.index_image";
+	private static final String WILDFLY_OPERATOR_CHANNEL = "intersmash.wildfly.operators.channel";
 	private static final String WILDFLY_OPERATOR_PACKAGE_MANIFEST = "intersmash.wildfly.operators.package_manifest";
 	private static final String COMMUNITY_WILDFLY_OPERATOR_PACKAGE_MANIFEST = "wildfly";
 	private static final String PRODUCT_WILDFLY_OPERATOR_PACKAGE_MANIFEST = "eap";
 	private static final String DEFAULT_WILDFLY_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_WILDFLY_OPERATOR_PACKAGE_MANIFEST;
 	private static final String KAFKA_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.kafka.operators.catalog_source";
 	private static final String KAFKA_OPERATOR_INDEX_IMAGE = "intersmash.kafka.operators.index_image";
+	private static final String KAFKA_OPERATOR_CHANNEL = "intersmash.kafka.operators.channel";
 	private static final String KAFKA_OPERATOR_PACKAGE_MANIFEST = "intersmash.kafka.operators.package_manifest";
 	private static final String COMMUNITY_KAFKA_OPERATOR_PACKAGE_MANIFEST = "kafka";
 	private static final String PRODUCT_KAFKA_OPERATOR_PACKAGE_MANIFEST = "amq-streams";
 	private static final String DEFAULT_KAFKA_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_KAFKA_OPERATOR_PACKAGE_MANIFEST;
 	private static final String ACTIVEMQ_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.activemq.operators.catalog_source";
 	private static final String ACTIVEMQ_OPERATOR_INDEX_IMAGE = "intersmash.activemq.operators.index_image";
+	private static final String ACTIVEMQ_OPERATOR_CHANNEL = "intersmash.activemq.operators.channel";
 	private static final String ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "intersmash.activemq.operators.package_manifest";
 	private static final String COMMUNITY_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "artemis";
 	private static final String PRODUCT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "amq-broker-rhel8";
 	private static final String DEFAULT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST;
 	private static final String HYPERFOIL_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.hyperfoil.operators.catalog_source";
 	private static final String HYPERFOIL_OPERATOR_INDEX_IMAGE = "intersmash.hyperfoil.operators.index_image";
+	private static final String HYPERFOIL_OPERATOR_CHANNEL = "intersmash.hyperfoil.operators.channel";
 	private static final String HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = "intersmash.hyperfoil.operators.package_manifest";
 	private static final String COMMUNITY_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = "hyperfoil-bundle";
 	private static final String DEFAULT_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST;
-
 	// Bootable Jar
 	private static final String BOOTABLE_JAR_IMAGE_URL = "intersmash.bootable.jar.image";
 
@@ -134,6 +139,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(INFINISPAN_OPERATOR_INDEX_IMAGE);
 	}
 
+	public static String infinispanOperatorChannel() {
+		return XTFConfig.get(INFINISPAN_OPERATOR_CHANNEL);
+	}
+
 	public static String infinispanOperatorPackageManifest() {
 		return XTFConfig.get(INFINISPAN_OPERATOR_PACKAGE_MANIFEST, DEFAULT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST);
 	}
@@ -144,6 +153,10 @@ public class IntersmashConfig {
 
 	public static String keycloakOperatorIndexImage() {
 		return XTFConfig.get(KEYCLOAK_OPERATOR_INDEX_IMAGE);
+	}
+
+	public static String keycloakOperatorChannel() {
+		return XTFConfig.get(KEYCLOAK_OPERATOR_CHANNEL);
 	}
 
 	public static String keycloakOperatorPackageManifest() {
@@ -158,6 +171,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(WILDFLY_OPERATOR_INDEX_IMAGE);
 	}
 
+	public static String wildflyOperatorChannel() {
+		return XTFConfig.get(WILDFLY_OPERATOR_CHANNEL);
+	}
+
 	public static String wildflyOperatorPackageManifest() {
 		return XTFConfig.get(WILDFLY_OPERATOR_PACKAGE_MANIFEST, DEFAULT_WILDFLY_OPERATOR_PACKAGE_MANIFEST);
 	}
@@ -168,6 +185,10 @@ public class IntersmashConfig {
 
 	public static String kafkaOperatorIndexImage() {
 		return XTFConfig.get(KAFKA_OPERATOR_INDEX_IMAGE);
+	}
+
+	public static String kafkaOperatorChannel() {
+		return XTFConfig.get(KAFKA_OPERATOR_CHANNEL);
 	}
 
 	public static String kafkaOperatorPackageManifest() {
@@ -182,8 +203,28 @@ public class IntersmashConfig {
 		return XTFConfig.get(ACTIVEMQ_OPERATOR_INDEX_IMAGE);
 	}
 
+	public static String activeMQOperatorChannel() {
+		return XTFConfig.get(ACTIVEMQ_OPERATOR_CHANNEL);
+	}
+
 	public static String activeMQOperatorPackageManifest() {
 		return XTFConfig.get(ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST, DEFAULT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST);
+	}
+
+	public static String hyperfoilOperatorCatalogSource() {
+		return XTFConfig.get(HYPERFOIL_OPERATOR_CATALOG_SOURCE_NAME, COMMUNITY_OPERATOR_CATALOG_SOURCE_NAME);
+	}
+
+	public static String hyperfoilOperatorIndexImage() {
+		return XTFConfig.get(HYPERFOIL_OPERATOR_INDEX_IMAGE);
+	}
+
+	public static String hyperfoilOperatorChannel() {
+		return XTFConfig.get(HYPERFOIL_OPERATOR_CHANNEL);
+	}
+
+	public static String hyperfoilOperatorPackageManifest() {
+		return XTFConfig.get(HYPERFOIL_OPERATOR_PACKAGE_MANIFEST, DEFAULT_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST);
 	}
 
 	public static String bootableJarImageURL() {
@@ -300,18 +341,6 @@ public class IntersmashConfig {
 	 */
 	public static String deploymentsRepositoryRef() {
 		return XTFConfig.get(DEPLOYMENTS_REPOSITORY_REF, IntersmashDeploymentsGitHelper.repositoryReference());
-	}
-
-	public static String hyperfoilOperatorIndexImage() {
-		return XTFConfig.get(HYPERFOIL_OPERATOR_INDEX_IMAGE);
-	}
-
-	public static String hyperfoilOperatorCatalogSource() {
-		return XTFConfig.get(HYPERFOIL_OPERATOR_CATALOG_SOURCE_NAME, COMMUNITY_OPERATOR_CATALOG_SOURCE_NAME);
-	}
-
-	public static String hyperfoilOperatorPackageManifest() {
-		return XTFConfig.get(HYPERFOIL_OPERATOR_PACKAGE_MANIFEST, DEFAULT_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST);
 	}
 
 	public static String getWildflyMavenPluginGroupId() {

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/openshift/operator/OperatorProvisioner.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/openshift/operator/OperatorProvisioner.java
@@ -64,8 +64,6 @@ public abstract class OperatorProvisioner<T extends OperatorApplication> impleme
 	private final T operatorApplication;
 	private PackageManifest packageManifest;
 	private String operatorChannel;
-	private final String desiredChannel;
-
 	protected FailFastCheck ffCheck = () -> false;
 	private OpenShift adminShift;
 	private OpenShiftBinary adminBinary;
@@ -73,13 +71,8 @@ public abstract class OperatorProvisioner<T extends OperatorApplication> impleme
 	public static final String INSTALLPLAN_APPROVAL_MANUAL = "Manual";
 
 	public OperatorProvisioner(T operatorApplication, String packageManifestName) {
-		this(operatorApplication, packageManifestName, null);
-	}
-
-	public OperatorProvisioner(T operatorApplication, String packageManifestName, String desiredChannel) {
 		this.operatorApplication = operatorApplication;
 		this.packageManifestName = packageManifestName;
-		this.desiredChannel = desiredChannel;
 	}
 
 	@Override
@@ -97,7 +90,8 @@ public abstract class OperatorProvisioner<T extends OperatorApplication> impleme
 		final String defaultChannel = packageManifest.getStatus().getDefaultChannel();
 
 		// if there is no specific desired channel for Operator installation, let's use the default one.
-		this.operatorChannel = (desiredChannel != null) ? desiredChannel : defaultChannel;
+		final String desiredChannel = this.getOperatorChannel();
+		this.operatorChannel = (desiredChannel != null && !desiredChannel.isEmpty()) ? desiredChannel : defaultChannel;
 
 		PackageChannel packageChannel = initPackageChannel(operatorChannel);
 
@@ -117,6 +111,8 @@ public abstract class OperatorProvisioner<T extends OperatorApplication> impleme
 	protected abstract String getOperatorCatalogSource();
 
 	protected abstract String getOperatorIndexImage();
+
+	protected abstract String getOperatorChannel();
 
 	/**
 	 * The CatalogSource is in the "openshift-marketplace" namespace by default;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/ActiveMQOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/ActiveMQOperatorProvisioner.java
@@ -243,4 +243,9 @@ public class ActiveMQOperatorProvisioner extends OperatorProvisioner<ActiveMQOpe
 	protected String getOperatorIndexImage() {
 		return IntersmashConfig.activeMQOperatorIndexImage();
 	}
+
+	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.activeMQOperatorChannel();
+	}
 }

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/HyperfoilOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/HyperfoilOperatorProvisioner.java
@@ -62,7 +62,7 @@ public class HyperfoilOperatorProvisioner extends OperatorProvisioner<HyperfoilO
 	private static final String OPERATOR_ID = IntersmashConfig.hyperfoilOperatorPackageManifest();
 
 	public HyperfoilOperatorProvisioner(@NonNull HyperfoilOperatorApplication hyperfoilOperatorApplication) {
-		super(hyperfoilOperatorApplication, OPERATOR_ID, null);
+		super(hyperfoilOperatorApplication, OPERATOR_ID);
 	}
 
 	public static String getOperatorId() {
@@ -220,6 +220,11 @@ public class HyperfoilOperatorProvisioner extends OperatorProvisioner<HyperfoilO
 	@Override
 	protected String getOperatorIndexImage() {
 		return IntersmashConfig.hyperfoilOperatorIndexImage();
+	}
+
+	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.hyperfoilOperatorChannel();
 	}
 
 	@Override

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/InfinispanOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/InfinispanOperatorProvisioner.java
@@ -153,6 +153,11 @@ public class InfinispanOperatorProvisioner extends OperatorProvisioner<Infinispa
 		return IntersmashConfig.infinispanOperatorIndexImage();
 	}
 
+	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.infinispanOperatorChannel();
+	}
+
 	/**
 	 * The result is affected by the CR definition and specifically the method will return the {@code service} URL in
 	 * case the CR {@code .spec.expose.type} is set to {@code NodePort} or {@code LoadBalancer} while it will return the

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KafkaOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KafkaOperatorProvisioner.java
@@ -366,4 +366,9 @@ public class KafkaOperatorProvisioner extends OperatorProvisioner<KafkaOperatorA
 	protected String getOperatorIndexImage() {
 		return IntersmashConfig.kafkaOperatorIndexImage();
 	}
+
+	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.kafkaOperatorChannel();
+	}
 }

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakOperatorProvisioner.java
@@ -97,6 +97,11 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 	}
 
 	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.keycloakOperatorChannel();
+	}
+
+	@Override
 	public void subscribe() {
 		if (Strings.isNullOrEmpty(IntersmashConfig.keycloakImageURL())) {
 			super.subscribe();

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
@@ -49,7 +49,7 @@ public class WildflyOperatorProvisioner extends OperatorProvisioner<WildflyOpera
 	private static final String OPERATOR_ID = IntersmashConfig.wildflyOperatorPackageManifest();
 
 	public WildflyOperatorProvisioner(@NonNull WildflyOperatorApplication wildflyOperatorApplication) {
-		super(wildflyOperatorApplication, OPERATOR_ID, "alpha");
+		super(wildflyOperatorApplication, OPERATOR_ID);
 	}
 
 	public static String getOperatorId() {
@@ -168,6 +168,11 @@ public class WildflyOperatorProvisioner extends OperatorProvisioner<WildflyOpera
 	@Override
 	protected String getOperatorIndexImage() {
 		return IntersmashConfig.wildflyOperatorIndexImage();
+	}
+
+	@Override
+	protected String getOperatorChannel() {
+		return IntersmashConfig.wildflyOperatorChannel();
 	}
 
 	@Override


### PR DESCRIPTION
## Description
Introducing the new property `intersmash.operators.*.channel` that allows for externalized configuration of a given Operator desired channel to override the default one.

Fix #26 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
