### PR TITLE
[issue 21] - Enabling WildFlyOperatorProvisionerTest

### DIFF
--- a/.ci/openshift-ci/build-root/e2e-test.sh
+++ b/.ci/openshift-ci/build-root/e2e-test.sh
@@ -45,6 +45,11 @@ xtf.openshift.master.password=${SYSADMIN_PASSWORD}
 xtf.openshift.master.token=${SYSADMIN_TOKEN}
 xtf.openshift.admin.kubeconfig=${KUBECONFIG}
 xtf.openshift.master.kubeconfig=${KUBECONFIG}
+
+# WildFly community operator settings
+intersmash.wildfly.operators.catalog_source=community-operators-wildfly-operator
+intersmash.wildfly.operators.index_image=quay.io/operatorhubio/catalog:latest
+intersmash.wildfly.operators.package_manifest=wildfly
 EOL
 
 cat test.properties

--- a/README.md
+++ b/README.md
@@ -277,9 +277,10 @@ a given service on cloud environments via APIs that leverage the
 Intersmash makes this feature available for currently supported products (see the table below), but that can be 
 extended easily, since Intersmash _provisioners_ are pluggable components.
 
-| Product    | Supported Operator version | Default channel name | Supported product version | Repository                                        | Notes |
-|:-----------|:---------------------------|:---------------------|:--------------------------|:--------------------------------------------------|:------|
-| Infinispan | 2.3.1                      | 2.3.x                | 14.0.6.Final              | https://github.com/infinispan/infinispan-operator |       |
+| Product    | Supported Operator version | Channel name | Supported product version | Repository                                        | Notes                                                   |
+|:-----------|:---------------------------|:-------------|:--------------------------|:--------------------------------------------------|:--------------------------------------------------------|
+| Infinispan | 2.3.1                      | 2.3.x        | 14.0.6.Final              | https://github.com/infinispan/infinispan-operator |                                                         |
+| WildFly    | 0.5.6                      | alpha        | 27.0.1.Final              | https://github.com/wildfly/wildfly-operator       | As available on https://operatorhub.io/operator/wildfly |
 
 
 Intersmash operator-based provisioners implement a common contract and high level behavior which is defined by the 

--- a/global-test.properties
+++ b/global-test.properties
@@ -11,3 +11,8 @@ xtf.junit.prebuilder.synchronized=true
 
 # Bootable jar
 intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
+
+# WildFly
+intersmash.wildfly.operators.catalog_source=community-operators-wildfly-operator
+intersmash.wildfly.operators.index_image=quay.io/operatorhubio/catalog
+intersmash.wildfly.operators.package_manifest=wildfly

--- a/global-test.properties
+++ b/global-test.properties
@@ -11,8 +11,3 @@ xtf.junit.prebuilder.synchronized=true
 
 # Bootable jar
 intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
-
-# WildFly
-intersmash.wildfly.operators.catalog_source=community-operators-wildfly-operator
-intersmash.wildfly.operators.index_image=quay.io/operatorhubio/catalog
-intersmash.wildfly.operators.package_manifest=wildfly

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/ActiveMQOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/ActiveMQOperatorProvisionerTest.java
@@ -70,7 +70,6 @@ public class ActiveMQOperatorProvisionerTest {
 						return DEFAULT_ACTIVEMQ_APP_NAME;
 					}
 				});
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
@@ -78,6 +77,7 @@ public class ActiveMQOperatorProvisionerTest {
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
+		activeMQOperatorProvisioner.configure();
 		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
 		OpenShifts.adminBinary().execute("apply", "-f", OperatorGroup.SINGLE_NAMESPACE.save().getAbsolutePath());
@@ -90,6 +90,7 @@ public class ActiveMQOperatorProvisionerTest {
 	@AfterAll
 	public static void removeOperatorGroup() {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
+		activeMQOperatorProvisioner.dismiss();
 	}
 
 	@AfterEach

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/HyperfoilOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/HyperfoilOperatorProvisionerTest.java
@@ -69,12 +69,12 @@ public class HyperfoilOperatorProvisionerTest {
 						return NAME;
 					}
 				});
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
+		hyperfoilOperatorProvisioner.configure();
 		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
 		OpenShifts.adminBinary().execute("apply", "-f", OperatorGroup.SINGLE_NAMESPACE.save().getAbsolutePath());
@@ -87,6 +87,7 @@ public class HyperfoilOperatorProvisionerTest {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
 		// there might be leftovers in case of failures
 		OpenShifts.admin().deletePods("role", "agent");
+		hyperfoilOperatorProvisioner.dismiss();
 	}
 
 	/**

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/InfinispanOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/InfinispanOperatorProvisionerTest.java
@@ -88,7 +88,6 @@ public class InfinispanOperatorProvisionerTest {
 						return DEFAULT_INFINISPAN_APP_NAME;
 					}
 				});
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
@@ -97,10 +96,10 @@ public class InfinispanOperatorProvisionerTest {
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
-		matchLabels.put("app", "datagrid");
-		IntersmashExtension.operatorCleanup();
 		// let's configure the provisioner
 		INFINISPAN_OPERATOR_PROVISIONER.configure();
+		matchLabels.put("app", "datagrid");
+		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
 		OpenShifts.adminBinary().execute("apply", "-f", OperatorGroup.SINGLE_NAMESPACE.save().getAbsolutePath());
 		// clean any leftovers
@@ -110,6 +109,7 @@ public class InfinispanOperatorProvisionerTest {
 	@AfterAll
 	public static void removeOperatorGroup() {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
+		INFINISPAN_OPERATOR_PROVISIONER.dismiss();
 	}
 
 	@AfterEach

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KafkaOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KafkaOperatorProvisionerTest.java
@@ -45,12 +45,12 @@ public class KafkaOperatorProvisionerTest {
 
 	private static KafkaOperatorProvisioner initializeOperatorProvisioner() {
 		KafkaOperatorProvisioner operatorProvisioner = new KafkaOperatorProvisioner(application);
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
+		operatorProvisioner.configure();
 		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
 		OpenShifts.adminBinary().execute("apply", "-f", OperatorGroup.SINGLE_NAMESPACE.save().getAbsolutePath());
@@ -62,6 +62,7 @@ public class KafkaOperatorProvisionerTest {
 	@AfterAll
 	public static void removeOperatorGroup() {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
+		operatorProvisioner.dismiss();
 	}
 
 	@AfterEach

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KeycloakOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KeycloakOperatorProvisionerTest.java
@@ -95,7 +95,6 @@ public class KeycloakOperatorProvisionerTest {
 						return DEFAULT_KEYCLOAK_APP_NAME;
 					}
 				});
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
@@ -105,6 +104,7 @@ public class KeycloakOperatorProvisionerTest {
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
+		KEYCLOAK_OPERATOR_PROVISIONER.configure();
 		matchLabels.put("app", "sso");
 		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
@@ -116,6 +116,7 @@ public class KeycloakOperatorProvisionerTest {
 	@AfterAll
 	public static void removeOperatorGroup() {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
+		KEYCLOAK_OPERATOR_PROVISIONER.dismiss();
 	}
 
 	@AfterEach

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyOperatorProvisionerTest.java
@@ -55,12 +55,12 @@ public class WildflyOperatorProvisionerTest {
 						return NAME;
 					}
 				});
-		operatorProvisioner.configure();
 		return operatorProvisioner;
 	}
 
 	@BeforeAll
 	public static void createOperatorGroup() throws IOException {
+		WILDFLY_OPERATOR_PROVISIONER.configure();
 		IntersmashExtension.operatorCleanup();
 		// create operator group - this should be done by InteropExtension
 		OpenShifts.adminBinary().execute("apply", "-f", OperatorGroup.SINGLE_NAMESPACE.save().getAbsolutePath());
@@ -71,6 +71,7 @@ public class WildflyOperatorProvisionerTest {
 	@AfterAll
 	public static void removeOperatorGroup() {
 		OpenShifts.adminBinary().execute("delete", "operatorgroup", "--all");
+		WILDFLY_OPERATOR_PROVISIONER.dismiss();
 	}
 
 	@AfterEach

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyOperatorProvisionerTest.java
@@ -17,7 +17,6 @@ package org.jboss.intersmash.testsuite.provision.openshift;
 
 import java.io.IOException;
 
-import org.jboss.intersmash.tools.IntersmashConfig;
 import org.jboss.intersmash.tools.application.openshift.WildflyOperatorApplication;
 import org.jboss.intersmash.tools.junit5.IntersmashExtension;
 import org.jboss.intersmash.tools.provision.openshift.WildflyOperatorProvisioner;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import cz.xtf.core.openshift.OpenShifts;
@@ -37,7 +35,6 @@ import cz.xtf.junit5.annotations.CleanBeforeAll;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 
 @CleanBeforeAll
-@Disabled("WIP - Disabled until global-test.properties is configured with the required property")
 public class WildflyOperatorProvisionerTest {
 	private static final String NAME = "wildfly-operator-test";
 	private static final WildflyOperatorProvisioner WILDFLY_OPERATOR_PROVISIONER = initializeOperatorProvisioner();
@@ -48,7 +45,7 @@ public class WildflyOperatorProvisionerTest {
 					@Override
 					public WildFlyServer getWildflyServer() {
 						return new WildFlyServerBuilder(getName())
-								.applicationImage(IntersmashConfig.wildflyImageURL())
+								.applicationImage("quay.io/wildfly/wildfly")
 								.replicas(1)
 								.build();
 					}

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/operator/OperatorSubscriptionTestCase.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/operator/OperatorSubscriptionTestCase.java
@@ -115,15 +115,19 @@ public class OperatorSubscriptionTestCase {
 
 	public void operatorSubscriptionTest() {
 		operatorProvisioner.configure();
-		// clean any leftovers
-		operatorProvisioner.unsubscribe();
-		operatorProvisioner.subscribe();
+		try {
+			// clean any leftovers
+			operatorProvisioner.unsubscribe();
+			operatorProvisioner.subscribe();
 
-		log.debug("Pods:");
-		OpenShifts.master().getPods().forEach(this::introducePod);
-		Assertions.assertTrue(operatorProvisioner.getCustomResourceDefinitions().size() > 0,
-				String.format("List of CRDs provided by operator [%s] should not be empty.",
-						operatorProvisioner.getPackageManifestName()));
+			log.debug("Pods:");
+			OpenShifts.master().getPods().forEach(this::introducePod);
+			Assertions.assertTrue(operatorProvisioner.getCustomResourceDefinitions().size() > 0,
+					String.format("List of CRDs provided by operator [%s] should not be empty.",
+							operatorProvisioner.getPackageManifestName()));
+		} finally {
+			operatorProvisioner.dismiss();
+		}
 	}
 
 	private void introducePod(Pod pod) {

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
@@ -18,6 +18,8 @@ package org.jboss.intersmash.tools;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.checkerframework.checker.units.qual.C;
+
 import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.openshift.OpenShifts;
 
@@ -112,6 +114,10 @@ public class IntersmashConfig {
 
 	public static boolean skipUndeploy() {
 		return skipDeploy() || XTFConfig.get(SKIP_UNDEPLOY, "false").equals("true");
+	}
+
+	public static String[] getKnownCatalogSources() {
+		return new String[] { COMMUNITY_OPERATOR_CATALOG_SOURCE_NAME, REDHAT_OPERATOR_CATALOG_SOURCE_NAME };
 	}
 
 	public static String defaultOperatorCatalogSourceName() {

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/IntersmashConfig.java
@@ -18,8 +18,6 @@ package org.jboss.intersmash.tools;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.checkerframework.checker.units.qual.C;
-
 import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.openshift.OpenShifts;
 

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/junit5/IntersmashExtension.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/junit5/IntersmashExtension.java
@@ -52,14 +52,6 @@ public class IntersmashExtension implements BeforeAllCallback, AfterAllCallback,
 
 	private static final Namespace NAMESPACE = Namespace.create("org", "jboss", "intersmash", "IntersmashExtension");
 	private static final String INTERSMASH_SERVICES = "INTERSMASH_SERVICES";
-	//	private OpenShiftRecorderService openShiftRecorderService;
-	//
-	//	private OpenShiftRecorderService openShiftRecorderService() {
-	//		if (openShiftRecorderService == null) {
-	//			openShiftRecorderService = new OpenShiftRecorderService();
-	//		}
-	//		return openShiftRecorderService;
-	//	}
 
 	@Override
 	public void beforeAll(ExtensionContext extensionContext) throws Exception {
@@ -106,11 +98,6 @@ public class IntersmashExtension implements BeforeAllCallback, AfterAllCallback,
 			}
 		} catch (Throwable t) {
 			tt = Optional.of(t);
-			//			try {
-			//				openShiftRecorderService().recordState(extensionContext);
-			//			} catch (Throwable th) {
-			//				log.error("Error getting OpenShift logs for Intersmash!", th);
-			//			}
 		} finally {
 			if (tt.isPresent())
 				throw new Exception("Error before test execution!", tt.get());
@@ -145,6 +132,7 @@ public class IntersmashExtension implements BeforeAllCallback, AfterAllCallback,
 		log.info("Undeploying ", provisioner.getApplication().getClass().getName());
 		provisioner.undeploy();
 		provisioner.postUndeploy();
+		provisioner.dismiss();
 	}
 
 	public void afterAll(ExtensionContext extensionContext) {

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/Provisioner.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/Provisioner.java
@@ -60,7 +60,19 @@ public interface Provisioner<T extends Application> {
 	 */
 	URL getURL();
 
+	/**
+	 * Defines an operation for configuring the provisioner, before any deployment related tasks are executed, e.g.:
+	 * for Operator based provisioners this allows for configuring custom catalog sources etc.
+	 */
 	default void configure() {
+		;
+	}
+
+	/**
+	 * Defines an operation for configuring the provisioner, after all deploy related tasks are executed, e.g.:
+	 * for Operator based provisioners this allows for removing custom catalog sources etc.
+	 */
+	default void dismiss() {
 		;
 	}
 }

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
@@ -49,7 +49,7 @@ public class WildflyOperatorProvisioner extends OperatorProvisioner<WildflyOpera
 	private static final String OPERATOR_ID = IntersmashConfig.wildflyOperatorPackageManifest();
 
 	public WildflyOperatorProvisioner(@NonNull WildflyOperatorApplication wildflyOperatorApplication) {
-		super(wildflyOperatorApplication, OPERATOR_ID, "stable");
+		super(wildflyOperatorApplication, OPERATOR_ID, "alpha");
 	}
 
 	public static String getOperatorId() {


### PR DESCRIPTION
## Description
Enabling the Wildfly operator based provisioner test in the Intersmash testsuite.

There isn't a WildFly Operator image available on OpenShift operator hub, hence here we're using the one on [Operatorhub.io](https://operatorhub.io/operator/wildfly).
For this reason we leverage the following properties in global-test.properties:

* `intersmash.wildfly.operators.catalog_source`
* `intersmash.wildfly.operators.index_image`
* `intersmash.wildfly.operators.package_manifest`

So that Intersmash will configure a custom catalog source for us and let the community operator be deployed.

Part of #21 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
