### PR TITLE
CLI_LAUNCH_SCRIPT defined automatically if `getCliScript` non-empty

### DIFF
--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenShiftProvisionerTestBase.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenShiftProvisionerTestBase.java
@@ -243,9 +243,8 @@ public class OpenShiftProvisionerTestBase {
 			public List<EnvVar> getEnvVars() {
 				List<EnvVar> list = new ArrayList<>();
 				list.add(new EnvVarBuilder().withName(TEST_ENV_VAR.getName()).withValue(TEST_ENV_VAR.getValue()).build());
-				list.add(new EnvVarBuilder().withName("CLI_LAUNCH_SCRIPT").withValue("/opt/server/extensions/configure.cli")
-						.build());
-
+				// Let's skip addition of the CLI_LAUNCH_SCRIPT environment variable here to test that it's added automatically
+				// in org.jboss.intersmash.tools.provision.openshift.WildflyImageOpenShiftProvisioner#deployImage().
 				list.add(new EnvVarBuilder().withName("ADMIN_USERNAME").withValue("admin").build());
 				list.add(new EnvVarBuilder().withName("ADMIN_PASSWORD").withValue("pass.1234").build());
 				if (!Strings.isNullOrEmpty(IntersmashConfig.getMavenMirrorUrl())) {


### PR DESCRIPTION
In case that application doesn't define the `CLI_LAUNCH_SCRIPT` environment property, let's define it automatically. This can prevent somebody to forget to define this variable in server provisioning.

## Description
<!--
Thank a lot for taking time to contribute to Intersmash <3!

Please provide a description of what your PR does, by providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
