### PR TITLE
[issue 39] - Fix WildFlyOperatorTest intermittent failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <version.jsonschema2pojo-maven-plugin>1.1.2</version.jsonschema2pojo-maven-plugin>
         <version.junit5.jupiter.system.stubs>2.0.1</version.junit5.jupiter.system.stubs>
         <version.spotless-maven-plugin>2.35.0</version.spotless-maven-plugin>
+        <version.dev-failsafe.failsafe>3.3.1</version.dev-failsafe.failsafe>
     </properties>
 
     <dependencyManagement>
@@ -174,6 +175,11 @@
                 <groupId>cz.xtf</groupId>
                 <artifactId>builder</artifactId>
                 <version>${xtf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.failsafe</groupId>
+                <artifactId>failsafe</artifactId>
+                <version>${version.dev-failsafe.failsafe}</version>
             </dependency>
             <!-- JUnit 5 Jupiter -->
             <dependency>

--- a/tools/intersmash-tools-core/pom.xml
+++ b/tools/intersmash-tools-core/pom.xml
@@ -19,6 +19,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+        <dependency>
             <groupId>cz.xtf</groupId>
             <artifactId>core</artifactId>
         </dependency>


### PR DESCRIPTION
## Description
Here we proposa a fix for the WIldyOperatorProvisioner, or actually the OperatorProvisioner itself, that fails occasionally when pulling the list of package manifests from a community catalog source, e.g.: quay.io/operatoruhubio/catalog.
The fix introducies a retry policy when listing community operators package manifests.

Fix #39 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift
