### PR TITLE
[issue 21] - Enabling WildflyImageProvisionerTest

### DIFF
--- a/global-test.properties
+++ b/global-test.properties
@@ -9,16 +9,20 @@ xtf.record.always=false
 # Avoid starting multiple builds at once as it might cause that builds starts to hang
 xtf.junit.prebuilder.synchronized=true
 
-# Bootable jar
+# Bootable JAR OpenJDK base image
 intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
 
-# WildFly community operator settings
+# WildFly operator settings
 intersmash.wildfly.operators.catalog_source=community-operators-wildfly-operator
 intersmash.wildfly.operators.index_image=quay.io/operatorhubio/catalog:latest
 intersmash.wildfly.operators.package_manifest=wildfly
 intersmash.wildfly.operators.channel=alpha
 
-# Kafka community operator settings
+# Wildfly images
+intersmash.wildfly.image=quay.io/wildfly/wildfly-s2i-jdk17
+intersmash.wildfly.runtime.image=quay.io/wildfly/wildfly-runtime-jdk17
+
+# Kafka operator settings
 intersmash.kafka.operators.channel=strimzi-0.29.x
 
 # DB

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyImageProvisionerTestCase.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/WildflyImageProvisionerTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.intersmash.tools.application.openshift.WildflyImageOpenShiftApp
 import org.jboss.intersmash.tools.provision.openshift.WildflyImageOpenShiftProvisioner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import cz.xtf.core.openshift.OpenShift;
@@ -40,14 +39,13 @@ import io.fabric8.openshift.api.model.GitBuildSource;
 
 /**
  * This test verifies a binary build can be executed using a remote git repository containing a maven project using the
- * wildfly-maven-plugin;
+ * wildfly-maven-plugin.
  * <br>
- * The code inside the remote git repository is uploaded to the builder image and the actual maven build is executed
- * inside the builder image with a command like the following:
+ * The code inside the remote git repository is pulled by the running Pod and the actual Maven build is executed
+ * inside the builder image.
  */
 @CleanBeforeAll
-@Disabled("Until we have a reliable way to provide snapshot artifacts to the Pods running s2i v2")
-public class WildflyImageTestCase {
+public class WildflyImageProvisionerTestCase {
 	private static final OpenShift openShift = OpenShifts.master();
 	private static final WildflyImageOpenShiftApplication application = OpenShiftProvisionerTestBase
 			.getWildflyOpenShiftImageApplication();

--- a/tools/intersmash-tools-provisioners/pom.xml
+++ b/tools/intersmash-tools-provisioners/pom.xml
@@ -145,6 +145,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources/filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <!--
                 We want for tests to be executed by Surefire, but we also add an XTF system property to the inherited

--- a/tools/intersmash-tools-provisioners/src/main/resources/filtered/intersmash-tools-provisioners.properties
+++ b/tools/intersmash-tools-provisioners/src/main/resources/filtered/intersmash-tools-provisioners.properties
@@ -1,0 +1,1 @@
+deploymentsBuildProfile=${intersmash.deployments.build.profile}


### PR DESCRIPTION
## Description
This enables the WildFlyImageProvisioner test which verifies that a Wildfly applicatin image can be built out of a Wildfly Maven plugin based project, which is pulled by the executing pod and then built into an image first by using the Wildfly builder image and thenn by applying the resulting deployiment onto a WildFly runtime image. 

Part of #21 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
