### PR TITLE
[Security update] - Bump gson version from 2.8.6 to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.io.swagger.core.v3>2.2.1</version.io.swagger.core.v3>
         <version.com.squareup.okhttp>2.7.5</version.com.squareup.okhttp>
         <!-- Hyperfoil -->
-        <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
+        <version.com.google.code.gson>2.10.1</version.com.google.code.gson>
         <version.io.gsonfire>1.8.4</version.io.gsonfire>
         <version.org.threeten>1.6.0</version.org.threeten>
         <version.io.swagger>1.5.24</version.io.swagger>


### PR DESCRIPTION
Bump gson version from 2.8.6 to 2.10.1, see https://github.com/Intersmash/intersmash/pull/22

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
