### PR TITLE
[Upgrade Fabric8 Kubernetes Client to 6.8.1] - Solving broken APIs changes

### DIFF
--- a/global-test.properties
+++ b/global-test.properties
@@ -36,7 +36,7 @@ intersmash.activemq.operators.package_manifest=activemq-artemis-operator
 intersmash.activemq.operators.channel=upstream
 
 # Kafka operator settings
-intersmash.kafka.operators.channel=strimzi-0.29.x
+intersmash.kafka.operators.channel=stable
 
 # DB
 intersmash.mysql.image=quay.io/centos7/mysql-80-centos7

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,9 @@
 
         <!--
             Using XTF snapshot in order to include fixes in:
-            https://github.com/xtf-cz/xtf/commit/a833c545082b314db538ed0c73e93310752654f7
-            https://github.com/xtf-cz/xtf/commit/0ed7dc16c88087ce9073a447311be6c01a520f8a
+            https://github.com/xtf-cz/xtf/pull/532
         -->
-        <xtf.version>0.31-202305291230-SNAPSHOT</xtf.version>
+        <xtf.version>0.31-update_kn_client-SNAPSHOT</xtf.version>
 
         <version.junit.jupiter>5.7.0</version.junit.jupiter>
 
@@ -39,10 +38,11 @@
         <version.logback>1.2.3</version.logback>
         <version.org.slf4j>1.7.30</version.org.slf4j>
         <version.ide-config>1.1</version.ide-config>
-        <version.io.strimzi-api>0.28.0</version.io.strimzi-api>
+        <!-- Strimzi 0.37 SNAPSHOT to have Fabric8 kubernetes client version aligned with XTF (6.8.1) -->
+        <version.io.strimzi-api>0.37.0-SNAPSHOT</version.io.strimzi-api>
         <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
-        <version.io.fabric8>6.6.0</version.io.fabric8>
-        <version.openshift-client>5.12.2</version.openshift-client>
+        <version.io.fabric8>6.8.1</version.io.fabric8>
+        <version.openshift-client>6.8.1</version.openshift-client>
 
         <!--
             Version used for the activemq-artemis-operator;
@@ -295,6 +295,10 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>kubernetes-model-common</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-client-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <!-- The following ones are used by the generated code for the Hyperfoil APIs -->
@@ -343,6 +347,11 @@
                 <groupId>uk.org.webcompere</groupId>
                 <artifactId>system-stubs-jupiter</artifactId>
                 <version>${version.junit5.jupiter.system.stubs}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-model-core</artifactId>
+                <version>${version.io.fabric8}</version>
             </dependency>
             <dependency>
                 <groupId>io.fabric8</groupId>
@@ -597,6 +606,18 @@
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <!-- Strimzi 0.37 SNAPSHOT to have Fabric8 kubernetes client version aligned with XTF (6.8.1) -->
+        <repository>
+            <id>ossrh-s</id>
+            <name>OSS Sonatype Snapshots Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
             </snapshots>
             <releases>
                 <enabled>false</enabled>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -48,6 +48,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KeycloakRealmImportOperatorProvisionerTest.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/KeycloakRealmImportOperatorProvisionerTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.keycloak.k8s.v2alpha1.Keycloak;
 import org.keycloak.k8s.v2alpha1.KeycloakRealmImport;
+import org.keycloak.k8s.v2alpha1.KeycloakRealmImportOperatorKeycloakList;
+import org.keycloak.k8s.v2alpha1.KeycloakRealmImportOperatorRealmImportList;
 import org.keycloak.k8s.v2alpha1.KeycloakRealmImportSpec;
 import org.keycloak.k8s.v2alpha1.KeycloakSpec;
 import org.keycloak.k8s.v2alpha1.keycloakrealmimportspec.Realm;
@@ -55,7 +57,6 @@ import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.SimpleWaiter;
 import cz.xtf.junit5.annotations.CleanBeforeAll;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import lombok.extern.slf4j.Slf4j;
@@ -315,9 +316,9 @@ public class KeycloakRealmImportOperatorProvisionerTest {
 	}
 
 	private void verifyKeycloak(Keycloak keycloak, KeycloakRealmImport realmImport, boolean waitForPods) {
-		NonNamespaceOperation<Keycloak, KubernetesResourceList<Keycloak>, Resource<Keycloak>> keycloakClient = KEYCLOAK_OPERATOR_PROVISIONER
+		NonNamespaceOperation<Keycloak, KeycloakRealmImportOperatorKeycloakList, Resource<Keycloak>> keycloakClient = KEYCLOAK_OPERATOR_PROVISIONER
 				.keycloakClient();
-		NonNamespaceOperation<KeycloakRealmImport, KubernetesResourceList<KeycloakRealmImport>, Resource<KeycloakRealmImport>> keycloakRealmImportClient = KEYCLOAK_OPERATOR_PROVISIONER
+		NonNamespaceOperation<KeycloakRealmImport, KeycloakRealmImportOperatorRealmImportList, Resource<KeycloakRealmImport>> keycloakRealmImportClient = KEYCLOAK_OPERATOR_PROVISIONER
 				.keycloakRealmImportClient();
 		// create and verify that object exists
 		keycloakClient.createOrReplace(keycloak);

--- a/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/openshift/operator/resources/Subscription.java
+++ b/tools/intersmash-tools-core/src/main/java/org/jboss/intersmash/tools/provision/openshift/operator/resources/Subscription.java
@@ -43,7 +43,8 @@ public class Subscription extends io.fabric8.openshift.api.model.operatorhub.v1a
 		super();
 	}
 
-	private SubscriptionFluent.SpecNested<SubscriptionBuilder> getConfiguredSubscriptionBuilder(String sourceNamespace,
+	private SubscriptionFluent<SubscriptionBuilder>.SpecNested<SubscriptionBuilder> getConfiguredSubscriptionBuilder(
+			String sourceNamespace,
 			String source, String name, String channel,
 			String installPlanApproval) {
 		return new SubscriptionBuilder()

--- a/tools/intersmash-tools-provisioners/pom.xml
+++ b/tools/intersmash-tools-provisioners/pom.xml
@@ -145,7 +145,16 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>generator-annotations</artifactId>
-            <version>6.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
     </dependencies>

--- a/tools/intersmash-tools-provisioners/pom.xml
+++ b/tools/intersmash-tools-provisioners/pom.xml
@@ -203,8 +203,8 @@
                         <url>https://raw.githubusercontent.com/artemiscloud/activemq-artemis-operator/${version.intersmash.activemq.operators}/bundle/manifests/broker.amq.io_activemqartemisaddresses.yaml</url>
                         <url>https://raw.githubusercontent.com/artemiscloud/activemq-artemis-operator/${version.intersmash.activemq.operators}/bundle/manifests/broker.amq.io_activemqartemisscaledowns.yaml</url>
                         <!-- Keycloak Operator -->
-                        <url>https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/21.1.1/kubernetes/keycloaks.k8s.keycloak.org-v1.yml</url>
-                        <url>https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/21.1.1/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml</url>
+                        <url>https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/22.0.1/kubernetes/keycloaks.k8s.keycloak.org-v1.yml</url>
+                        <url>https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/22.0.1/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml</url>
                     </urls>
                 </configuration>
             </plugin>

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/application/openshift/KafkaOperatorApplication.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/application/openshift/KafkaOperatorApplication.java
@@ -33,8 +33,8 @@ import io.strimzi.api.kafka.model.KafkaUser;
  */
 public interface KafkaOperatorApplication extends OperatorApplication {
 
-	String KAFKA_VERSION = "3.2.0";
-	String INTER_BROKER_PROTOCOL_VERSION = "3.2";
+	String KAFKA_VERSION = "3.5.1";
+	String INTER_BROKER_PROTOCOL_VERSION = "3.5";
 	int KAFKA_INSTANCE_NUM = 3;
 	int TOPIC_RECONCILIATION_INTERVAL_SECONDS = 90;
 	long USER_RECONCILIATION_INTERVAL_SECONDS = 120L;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/ActiveMQOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/ActiveMQOperatorProvisioner.java
@@ -77,9 +77,8 @@ public class ActiveMQOperatorProvisioner extends OperatorProvisioner<ActiveMQOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						ACTIVE_MQ_ARTEMIS_ADDRESS_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<ActiveMQArtemisAddress, ActiveMQArtemisAddressList, Resource<ActiveMQArtemisAddress>> addressesClient = OpenShifts
-					.master().customResources(crdc, ActiveMQArtemisAddress.class, ActiveMQArtemisAddressList.class);
+					.master().newHasMetadataOperation(crdc, ActiveMQArtemisAddress.class, ActiveMQArtemisAddressList.class);
 			ACTIVE_MQ_ARTEMIS_ADDRESSES_CLIENT = addressesClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return ACTIVE_MQ_ARTEMIS_ADDRESSES_CLIENT;
@@ -125,9 +124,8 @@ public class ActiveMQOperatorProvisioner extends OperatorProvisioner<ActiveMQOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						ACTIVE_MQ_ARTEMIS_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<ActiveMQArtemis, ActiveMQArtemisList, Resource<ActiveMQArtemis>> amqClient = OpenShifts
-					.master().customResources(crdc, ActiveMQArtemis.class, ActiveMQArtemisList.class);
+					.master().newHasMetadataOperation(crdc, ActiveMQArtemis.class, ActiveMQArtemisList.class);
 			ACTIVE_MQ_ARTEMISES_CLIENT = amqClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return ACTIVE_MQ_ARTEMISES_CLIENT;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/HyperfoilOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/HyperfoilOperatorProvisioner.java
@@ -84,7 +84,7 @@ public class HyperfoilOperatorProvisioner extends OperatorProvisioner<HyperfoilO
 						HYPERFOIL_CUSTOM_RESOURCE_DEFINITION, OPERATOR_ID));
 			}
 			MixedOperation<Hyperfoil, HyperfoilList, Resource<Hyperfoil>> hyperfoilCrClient = OpenShifts
-					.master().customResources(crdc, Hyperfoil.class, HyperfoilList.class);
+					.master().newHasMetadataOperation(crdc, Hyperfoil.class, HyperfoilList.class);
 			HYPERFOIL_CUSTOM_RESOURCE_CLIENT = hyperfoilCrClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return HYPERFOIL_CUSTOM_RESOURCE_CLIENT;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/InfinispanOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/InfinispanOperatorProvisioner.java
@@ -77,8 +77,9 @@ public class InfinispanOperatorProvisioner extends OperatorProvisioner<Infinispa
 		// create custom resources
 		int replicas = getApplication().getInfinispan().getSpec().getReplicas();
 		infinispansClient().createOrReplace(getApplication().getInfinispan());
-		if (getApplication().getCaches().size() > 0)
-			cachesClient().createOrReplace(getApplication().getCaches().stream().toArray(Cache[]::new));
+		if (getApplication().getCaches().size() > 0) {
+			getApplication().getCaches().stream().forEach((i) -> cachesClient().resource(i).create());
+		}
 
 		// This might be a litle bit naive, but we need more use cases to see how will this behave and what other
 		// use-cases we have to cover wait for infinispan pods - look for "clusterName" in infinispan pod
@@ -220,10 +221,9 @@ public class InfinispanOperatorProvisioner extends OperatorProvisioner<Infinispa
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						INFINISPAN_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<Infinispan, InfinispanList, Resource<Infinispan>> infinispansClient = OpenShifts
 					.master()
-					.customResources(crdc, Infinispan.class, InfinispanList.class);
+					.newHasMetadataOperation(crdc, Infinispan.class, InfinispanList.class);
 			INFINISPAN_CLIENT = infinispansClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return INFINISPAN_CLIENT;
@@ -254,10 +254,9 @@ public class InfinispanOperatorProvisioner extends OperatorProvisioner<Infinispa
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						INFINISPAN_CACHE_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<Cache, CacheList, Resource<Cache>> cachesClient = OpenShifts
 					.master()
-					.customResources(crdc, Cache.class, CacheList.class);
+					.newHasMetadataOperation(crdc, Cache.class, CacheList.class);
 			INFINISPAN_CACHES_CLIENT = cachesClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return INFINISPAN_CACHES_CLIENT;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KafkaOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KafkaOperatorProvisioner.java
@@ -252,7 +252,7 @@ public class KafkaOperatorProvisioner extends OperatorProvisioner<KafkaOperatorA
 		// delete the resources
 
 		if (getApplication().getUsers() != null) {
-			if (!kafkasUserClient().delete()) {
+			if (kafkasUserClient().delete().isEmpty()) {
 				log.warn("Wasn't able to remove all relevant 'Kafka User' resources created for '" + getApplication().getName()
 						+ "' instance!");
 			}
@@ -261,7 +261,7 @@ public class KafkaOperatorProvisioner extends OperatorProvisioner<KafkaOperatorA
 		}
 
 		if (getApplication().getTopics() != null) {
-			if (!kafkasTopicClient().delete()) {
+			if (kafkasTopicClient().delete().isEmpty()) {
 				log.warn("Wasn't able to remove all relevant 'Kafka Topic' resources created for '" + getApplication().getName()
 						+ "' instance!");
 			}
@@ -270,7 +270,7 @@ public class KafkaOperatorProvisioner extends OperatorProvisioner<KafkaOperatorA
 		}
 
 		if (getApplication().getKafka() != null) {
-			if (!kafka().withPropagationPolicy(DeletionPropagation.FOREGROUND).delete()) {
+			if (kafka().withPropagationPolicy(DeletionPropagation.FOREGROUND).delete().isEmpty()) {
 				log.warn("Wasn't able to remove all relevant 'Kafka' resources created for '" + getApplication().getName()
 						+ "' instance!");
 			}

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakOperatorProvisioner.java
@@ -125,16 +125,18 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 
 		// create custom resources
 		keycloaksClient().createOrReplace(getApplication().getKeycloak());
-		if (getApplication().getKeycloakRealms().size() > 0)
-			keycloakRealmsClient().createOrReplace(getApplication().getKeycloakRealms().stream().toArray(KeycloakRealm[]::new));
-		if (getApplication().getKeycloakClients().size() > 0)
-			keycloakClientsClient()
-					.createOrReplace(getApplication().getKeycloakClients().stream().toArray(KeycloakClient[]::new));
-		if (getApplication().getKeycloakUsers().size() > 0)
-			keycloakUsersClient().createOrReplace(getApplication().getKeycloakUsers().stream().toArray(KeycloakUser[]::new));
-		if (getApplication().getKeycloakBackups().size() > 0)
-			keycloakBackupsClient()
-					.createOrReplace(getApplication().getKeycloakBackups().stream().toArray(KeycloakBackup[]::new));
+		if (getApplication().getKeycloakRealms().size() > 0) {
+			getApplication().getKeycloakRealms().stream().forEach((i) -> keycloakRealmsClient().resource(i).create());
+		}
+		if (getApplication().getKeycloakClients().size() > 0) {
+			getApplication().getKeycloakClients().stream().forEach((i) -> keycloakClientsClient().resource(i).create());
+		}
+		if (getApplication().getKeycloakUsers().size() > 0) {
+			getApplication().getKeycloakUsers().stream().forEach((i) -> keycloakUsersClient().resource(i).create());
+		}
+		if (getApplication().getKeycloakBackups().size() > 0) {
+			getApplication().getKeycloakBackups().stream().forEach((i) -> keycloakBackupsClient().resource(i).create());
+		}
 
 		// Wait for Keycloak (and PostgreSQL) to be ready
 		waitFor(getApplication().getKeycloak());
@@ -287,10 +289,9 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						KEYCLOAK_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<Keycloak, KeycloakList, Resource<Keycloak>> keycloaksClient = OpenShifts
 					.master()
-					.customResources(crdc, Keycloak.class, KeycloakList.class);
+					.newHasMetadataOperation(crdc, Keycloak.class, KeycloakList.class);
 			KEYCLOAKS_CLIENT = keycloaksClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return KEYCLOAKS_CLIENT;
@@ -321,10 +322,9 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						KEYCLOAK_REALM_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<KeycloakRealm, KeycloakRealmList, Resource<KeycloakRealm>> keycloakRealmsClient = OpenShifts
 					.master()
-					.customResources(crdc, KeycloakRealm.class, KeycloakRealmList.class);
+					.newHasMetadataOperation(crdc, KeycloakRealm.class, KeycloakRealmList.class);
 			KEYCLOAK_REALMS_CLIENT = keycloakRealmsClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return KEYCLOAK_REALMS_CLIENT;
@@ -372,10 +372,9 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						KEYCLOAK_BACKUP_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<KeycloakBackup, KeycloakBackupList, Resource<KeycloakBackup>> keycloakBackupsClient = OpenShifts
 					.master()
-					.customResources(crdc, KeycloakBackup.class, KeycloakBackupList.class);
+					.newHasMetadataOperation(crdc, KeycloakBackup.class, KeycloakBackupList.class);
 			KEYCLOAK_BACKUPS_CLIENT = keycloakBackupsClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return KEYCLOAK_BACKUPS_CLIENT;
@@ -423,10 +422,9 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						KEYCLOAK_CLIENT_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<KeycloakClient, KeycloakClientList, Resource<KeycloakClient>> keycloakClientsClient = OpenShifts
 					.master()
-					.customResources(crdc, KeycloakClient.class, KeycloakClientList.class);
+					.newHasMetadataOperation(crdc, KeycloakClient.class, KeycloakClientList.class);
 			KEYCLOAK_CLIENTS_CLIENT = keycloakClientsClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return KEYCLOAK_CLIENTS_CLIENT;
@@ -474,10 +472,9 @@ public class KeycloakOperatorProvisioner extends OperatorProvisioner<KeycloakOpe
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						KEYCLOAK_USER_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<KeycloakUser, KeycloakUserList, Resource<KeycloakUser>> keycloakUsersClient = OpenShifts
 					.master()
-					.customResources(crdc, KeycloakUser.class, KeycloakUserList.class);
+					.newHasMetadataOperation(crdc, KeycloakUser.class, KeycloakUserList.class);
 			KEYCLOAK_USERS_CLIENT = keycloakUsersClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return KEYCLOAK_USERS_CLIENT;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakRealmImportOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/KeycloakRealmImportOperatorProvisioner.java
@@ -218,13 +218,13 @@ public class KeycloakRealmImportOperatorProvisioner extends OperatorProvisioner<
 					&& Objects.nonNull(res.get().getStatus())) {
 				KeycloakRealmImport imp = res.get();
 				return imp.getStatus().getConditions().stream().filter(
-						cond -> cond.getStatus()
+						cond -> cond.getStatus() != null
 								&& "Done".equalsIgnoreCase(cond.getType())
 								&& com.google.common.base.Strings.isNullOrEmpty(cond.getMessage()))
 						.count() == 1
 						&&
 						imp.getStatus().getConditions().stream().filter(
-								cond -> !cond.getStatus()
+								cond -> cond.getStatus() == null
 										&& "HasErrors".equalsIgnoreCase(cond.getType())
 										&& com.google.common.base.Strings.isNullOrEmpty(cond.getMessage()))
 								.count() == 1;
@@ -237,13 +237,13 @@ public class KeycloakRealmImportOperatorProvisioner extends OperatorProvisioner<
 		new SimpleWaiter(
 				() -> keycloak().get().getStatus().getConditions().stream().anyMatch(
 						condition -> "Ready".equalsIgnoreCase(condition.getType())
-								&& condition.getStatus()))
+								&& condition.getStatus() != null))
 				.reason("Wait for Keycloak resource to be ready").level(Level.DEBUG).waitFor();
 		if (getApplication().getKeycloakRealmImports().size() > 0)
 			new SimpleWaiter(() -> keycloakRealmImports().stream().allMatch(
 					realmImport -> realmImport.getStatus().getConditions().stream().anyMatch(
 							condition -> "Done".equalsIgnoreCase(condition.getType())
-									&& condition.getStatus())))
+									&& condition.getStatus() != null)))
 					.reason("Wait for KeycloakRealmImports to be done.").level(Level.DEBUG).waitFor();
 	}
 
@@ -320,7 +320,7 @@ public class KeycloakRealmImportOperatorProvisioner extends OperatorProvisioner<
 		new SimpleWaiter(
 				() -> keycloak().get().getStatus().getConditions().stream().anyMatch(
 						condition -> "Ready".equalsIgnoreCase(condition.getType())
-								&& condition.getStatus()))
+								&& condition.getStatus() != null))
 				.reason("Wait for Keycloak resource to be ready").level(Level.DEBUG).waitFor();
 		// check that route is up
 		if (originalReplicas == 0 && replicas > 0) {

--- a/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/jboss/intersmash/tools/provision/openshift/WildflyOperatorProvisioner.java
@@ -70,9 +70,8 @@ public class WildflyOperatorProvisioner extends OperatorProvisioner<WildflyOpera
 				throw new RuntimeException(String.format("[%s] custom resource is not provided by [%s] operator.",
 						WILDFLY_SERVER_RESOURCE, OPERATOR_ID));
 			}
-
 			MixedOperation<WildFlyServer, WildFlyServerList, Resource<WildFlyServer>> wildflyServersClient = OpenShifts
-					.master().customResources(crdc, WildFlyServer.class, WildFlyServerList.class);
+					.master().newHasMetadataOperation(crdc, WildFlyServer.class, WildFlyServerList.class);
 			WILDFLY_SERVERS_CLIENT = wildflyServersClient.inNamespace(OpenShiftConfig.namespace());
 		}
 		return WILDFLY_SERVERS_CLIENT;

--- a/tools/intersmash-tools-provisioners/src/main/java/org/keycloak/k8s/v2alpha1/KeycloakRealmImportOperatorKeycloakList.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/keycloak/k8s/v2alpha1/KeycloakRealmImportOperatorKeycloakList.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.k8s.v2alpha1;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class KeycloakRealmImportOperatorKeycloakList extends CustomResourceList<org.keycloak.k8s.v2alpha1.Keycloak> {
+}

--- a/tools/intersmash-tools-provisioners/src/main/java/org/keycloak/k8s/v2alpha1/KeycloakRealmImportOperatorRealmImportList.java
+++ b/tools/intersmash-tools-provisioners/src/main/java/org/keycloak/k8s/v2alpha1/KeycloakRealmImportOperatorRealmImportList.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.k8s.v2alpha1;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class KeycloakRealmImportOperatorRealmImportList
+		extends CustomResourceList<org.keycloak.k8s.v2alpha1.KeycloakRealmImport> {
+}


### PR DESCRIPTION
We need to bump Fabric8 Kubernetes client dependencies, e.g.: latest java-generator(from CRD) features require breking changes in the kubernetes model.
~This PR uses an XTF snapshot which is built from the following proposal for moving XTF to kubernetes-client 6.7.2 as well: https://github.com/RoyalKarma/xtf/pull/1~

This PR is using the following snapshots:

* XTF v. `0.31-update_kn_client-SNAPSHOT` snapshots, based on https://github.com/xtf-cz/xtf/pull/532
* `io.strimzi:api:0.37.0-SNAPSHOT` from https://oss.sonatype.org/service/local/repositories/snapshots/content/io/strimzi/strimzi/0.37.0-SNAPSHOT/ 

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
