### PR TITLE
CVE-2023-4759 - bump jgit to 6.6.1.202309021850-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
         <version.shrinkwrap>1.2.6</version.shrinkwrap>
 
-        <version.org.eclipse.jgit>5.9.0.202009080501-r</version.org.eclipse.jgit>
+        <version.org.eclipse.jgit>6.6.1.202309021850-r</version.org.eclipse.jgit>
         <version.maven-dependency-plugin>3.2.0</version.maven-dependency-plugin>
         <version.maven-deploy-plugin>3.0.0-M1</version.maven-deploy-plugin>
         <version.maven-source-plugin>3.2.1</version.maven-source-plugin>


### PR DESCRIPTION
## Description
Bumping jGit dependencies to a version that solves [CVE-2023-4759](https://github.com/advisories/GHSA-3p86-9955-h393)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift
