### PR TITLE
[CVE-2023-6378] - Manually bump logback-classic to 1.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <version.lombok>1.18.20</version.lombok>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.mockito.core>4.9.0</version.mockito.core>
-        <version.logback>1.2.3</version.logback>
+        <version.logback>1.2.13</version.logback>
         <version.org.slf4j>1.7.30</version.org.slf4j>
         <version.ide-config>1.1</version.ide-config>
         <version.io.strimzi-api>0.38.0</version.io.strimzi-api>


### PR DESCRIPTION
## Description
Manually bump logback-classic to 1.2.13 to resolve the [security alert](https://github.com/Intersmash/intersmash/security/dependabot/4).

Fix https://github.com/Intersmash/intersmash/security/dependabot/4

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift

