### PR TITLE
Enabling testsuite deployments configuration for using JBoss EAP XP 5 released bits

### DIFF
--- a/testsuite/deployments/deployments-provider/pom.xml
+++ b/testsuite/deployments/deployments-provider/pom.xml
@@ -84,6 +84,15 @@
             </properties>
         </profile>
         <profile>
+            <id>ts.wildfly.target-distribution.eapxp</id>
+            <properties>
+                <!--
+                    When this profile is active, the following property is set to have it available at runtime,
+                    see TestDeploymentProperties#getWildflyDeploymentsBuildProfile -->
+                <intersmash.deployments.wildfly.build.profile>eapxp</intersmash.deployments.wildfly.build.profile>
+            </properties>
+        </profile>
+        <profile>
             <id>doc</id>
             <build>
                 <plugins>

--- a/testsuite/deployments/wildfly-shared/pom.xml
+++ b/testsuite/deployments/wildfly-shared/pom.xml
@@ -289,7 +289,7 @@
                     Default version for the Bootable JAR Plugin is set here and can be overridden, e.g. also for pulling
                     the productized version
                 -->
-                <version.wildfly-jar-maven-plugin>9.0.1.Final-redhat-00009</version.wildfly-jar-maven-plugin>
+                <version.wildfly-jar-maven-plugin>9.0.1.Final-redhat-00010</version.wildfly-jar-maven-plugin>
             </properties>
             <build>
                 <pluginManagement>

--- a/testsuite/deployments/wildfly-shared/pom.xml
+++ b/testsuite/deployments/wildfly-shared/pom.xml
@@ -267,12 +267,22 @@
                 <!-- Default EAP XP `microprofile` BOM version is set here and can be overridden for pulling the right BOM -->
                 <bom.wildfly-microprofile.groupId>org.jboss.eap.xp</bom.wildfly-microprofile.groupId>
                 <bom.wildfly-microprofile.artifactId>wildfly-microprofile</bom.wildfly-microprofile.artifactId>
-                <bom.wildfly-microprofile.version>5.0.0.GA-redhat-20240221</bom.wildfly-microprofile.version>
-                <!-- EAP XP Channel coordinates -->
+                <bom.wildfly-microprofile.version>5.0.0.GA-redhat-00005</bom.wildfly-microprofile.version>
+                <!-- EAP XP 5 Channel coordinates -->
                 <wildfly.ee-channel.groupId>org.jboss.eap.channels</wildfly.ee-channel.groupId>
-                <wildfly.ee-channel.artifactId>eap-8.0-plus-eap-xp-5.0</wildfly.ee-channel.artifactId>
-                <wildfly.ee-channel.version>1.0.0.Final-redhat-00001</wildfly.ee-channel.version>
-                <wildfly.feature-pack.location>org.jboss.eap.xp:wildfly-galleon-pack:5.0.0.GA-redhat-20240221</wildfly.feature-pack.location>
+                <wildfly.ee-channel.artifactId>eap-xp-5.0</wildfly.ee-channel.artifactId>
+                <wildfly.ee-channel.version>1.0.0.GA-redhat-00006</wildfly.ee-channel.version>
+                <!--
+                    EAP XP 5 feature packs:
+
+                        - EAP = org.jboss.eap:wildfly-ee-galleon-pack (only EE specs included)
+                        - EAP XP = org.jboss.eap:wildfly-galleon-pack (EE specs as well as MP specs)
+                        - WF = org.wildfly:wildfly-galleon-pack (EE specs as well as MP specs)
+
+                    Note 1: WF builds have both `wildfly-galleon-pack` and `wildfly-ee-galleon-pack`
+                    Note 2: leave the feature-packs location to non-existing location, this proves parameters are passed correctly to the builder image
+                -->
+                <wildfly.feature-pack.location>org.jboss.eap.xp:wildfly-galleon-pack:5.0.0.GA-redhat-00005</wildfly.feature-pack.location>
             </properties>
             <build>
                 <pluginManagement>

--- a/testsuite/deployments/wildfly-shared/pom.xml
+++ b/testsuite/deployments/wildfly-shared/pom.xml
@@ -264,6 +264,10 @@
             <!-- Configuration settings for testing EAP XP -->
             <id>ts.wildfly.target-distribution.eapxp</id>
             <properties>
+                <!-- WildFly/EAP 8 Maven Plugin coordinates -->
+                <wildfly-maven-plugin.groupId>org.jboss.eap.plugins</wildfly-maven-plugin.groupId>
+                <wildfly-maven-plugin.artifactId>eap-maven-plugin</wildfly-maven-plugin.artifactId>
+                <wildfly-maven-plugin.version>1.0.0.Final-redhat-00014</wildfly-maven-plugin.version>
                 <!-- Default EAP XP `microprofile` BOM version is set here and can be overridden for pulling the right BOM -->
                 <bom.wildfly-microprofile.groupId>org.jboss.eap.xp</bom.wildfly-microprofile.groupId>
                 <bom.wildfly-microprofile.artifactId>wildfly-microprofile</bom.wildfly-microprofile.artifactId>
@@ -304,15 +308,15 @@
                                         <location>${wildfly.feature-pack.location}</location>
                                     </feature-pack>
                                 </feature-packs>
-                                <channels>
-                                    <channel>
-                                        <manifest>
-                                            <groupId>${wildfly.ee-channel.groupId}</groupId>
-                                            <artifactId>${wildfly.ee-channel.artifactId}</artifactId>
-                                            <version>${wildfly.ee-channel.version}</version>
-                                        </manifest>
-                                    </channel>
-                                </channels>
+<!--                                <channels>-->
+<!--                                    <channel>-->
+<!--                                        <manifest>-->
+<!--                                            <groupId>${wildfly.ee-channel.groupId}</groupId>-->
+<!--                                            <artifactId>${wildfly.ee-channel.artifactId}</artifactId>-->
+<!--                                            <version>${wildfly.ee-channel.version}</version>-->
+<!--                                        </manifest>-->
+<!--                                    </channel>-->
+<!--                                </channels>-->
                             </configuration>
                         </plugin>
                     </plugins>

--- a/testsuite/deployments/wildfly-shared/pom.xml
+++ b/testsuite/deployments/wildfly-shared/pom.xml
@@ -283,6 +283,8 @@
                     Note 2: leave the feature-packs location to non-existing location, this proves parameters are passed correctly to the builder image
                 -->
                 <wildfly.feature-pack.location>org.jboss.eap.xp:wildfly-galleon-pack:5.0.0.GA-redhat-00005</wildfly.feature-pack.location>
+                <wildfly.ee-feature-pack.location>${wildfly.feature-pack.location}</wildfly.ee-feature-pack.location>
+                <wildfly.cloud-feature-pack.location>org.jboss.eap.xp.cloud:eap-xp-cloud-galleon-pack:1.0.0.Final-redhat-00006</wildfly.cloud-feature-pack.location>
             </properties>
             <build>
                 <pluginManagement>

--- a/testsuite/deployments/wildfly-shared/pom.xml
+++ b/testsuite/deployments/wildfly-shared/pom.xml
@@ -283,8 +283,13 @@
                     Note 2: leave the feature-packs location to non-existing location, this proves parameters are passed correctly to the builder image
                 -->
                 <wildfly.feature-pack.location>org.jboss.eap.xp:wildfly-galleon-pack:5.0.0.GA-redhat-00005</wildfly.feature-pack.location>
-                <wildfly.ee-feature-pack.location>${wildfly.feature-pack.location}</wildfly.ee-feature-pack.location>
+                <wildfly.ee-feature-pack.location>org.jboss.eap:wildfly-ee-galleon-pack:8.0.0.GA-redhat-00011</wildfly.ee-feature-pack.location>
                 <wildfly.cloud-feature-pack.location>org.jboss.eap.xp.cloud:eap-xp-cloud-galleon-pack:1.0.0.Final-redhat-00006</wildfly.cloud-feature-pack.location>
+                <!--
+                    Default version for the Bootable JAR Plugin is set here and can be overridden, e.g. also for pulling
+                    the productized version
+                -->
+                <version.wildfly-jar-maven-plugin>9.0.1.Final-redhat-00009</version.wildfly-jar-maven-plugin>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
## Description
Fixing the `testsuite` deployments in order to use released XP 5 bits when building with the XP 5 profile.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] Pull Request contains a description of the changes
 - [ ] Pull Request does not include fixes for multiple issues/topics
 - [ ] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
