### PR TITLE
Removed the method CommandLineBasedKeystoreGenerator::getSplitCommand…

### DIFF
--- a/core/src/main/java/org/jboss/intersmash/util/CommandLineBasedKeystoreGenerator.java
+++ b/core/src/main/java/org/jboss/intersmash/util/CommandLineBasedKeystoreGenerator.java
@@ -88,8 +88,7 @@ public class CommandLineBasedKeystoreGenerator {
 							+ " -showcerts 2>/dev/null > serversOpenSslResponse");
 			processCall(caDir, "/bin/sh",
 					"-c",
-					getSplitCommandNameBasedOnOeratingSystem()
-							+ " -f serverCert -s serversOpenSslResponse '/^-----BEGIN CERTIFICATE-----$/' '{*}'");
+					"csplit -f serverCert -s serversOpenSslResponse '/^-----BEGIN CERTIFICATE-----$/' '{*}'");
 			processCall(caDir, "/bin/sh",
 					"-c",
 					"find . -type f -not -name \"serverCert00\" -name \"serverCert[0-9][0-9]\" -exec openssl x509 -in {} -out {}.pem \\;");
@@ -291,10 +290,6 @@ public class CommandLineBasedKeystoreGenerator {
 		server = server.endsWith("/") ? server.substring(0, server.length() - 1) : server;
 		server = server.contains(":") ? server : server + ":443";
 		return server;
-	}
-
-	private static String getSplitCommandNameBasedOnOeratingSystem() {
-		return System.getProperty("os.name").toLowerCase().startsWith("mac") ? "gcsplit" : "csplit";
 	}
 
 	private static void processCall(Path cwd, String... args) {


### PR DESCRIPTION
…NameBasedOnOeratingSystem

Fixes issue #198 

Removed the above mentioned method. It was returning "gcsplit" when the "os.name" property was "mac", and "csplit" otherwise.

Since Intersmash supports only Linux execution, I hardcoded the value "csplit" where the method call was returning this value, as it is not supposed to change.

## Description
<!--
Thank a lot for taking time to contribute to Intersmash <3!

Please provide a description of what your PR does, by providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
