### PR TITLE
[issues-207] - Fix how Maven additioanl args for s2i OpenSHift builds are built by WildFly related application descriptors

### DIFF
--- a/testsuite/deployments/deployments-provider/src/main/java/org/jboss/intersmash/test/deployments/WildflyDeploymentApplicationConfiguration.java
+++ b/testsuite/deployments/deployments-provider/src/main/java/org/jboss/intersmash/test/deployments/WildflyDeploymentApplicationConfiguration.java
@@ -102,12 +102,21 @@ public interface WildflyDeploymentApplicationConfiguration {
 	}
 
 	/**
+	 * This must match the property name in the pom.xml file used to set the "wildfly-galleon-pack" feature pack GAV
+	 *
+	 * @return property name in the pom.xml file used to set the feature pack GAV
+	 */
+	default String featurePackLocationPropertyName() {
+		return WILDFLY_FEATURE_PACK_LOCATION;
+	}
+
+	/**
 	 * This must match the property name in the pom.xml file used to set the "wildfly-ee-galleon-pack" feature pack GAV
 	 *
 	 * @return property name in the pom.xml file used to set the feature pack GAV
 	 */
 	default String eeFeaturePackLocationPropertyName() {
-		return WILDFLY_FEATURE_PACK_LOCATION;
+		return WILDFLY_EE_FEATURE_PACK_LOCATION;
 	}
 
 	/**
@@ -206,7 +215,7 @@ public interface WildflyDeploymentApplicationConfiguration {
 				: (" -D" + this.eeFeaturePackLocationPropertyName() + "="
 						+ this.eeFeaturePackLocation())))
 				+ ((Strings.isNullOrEmpty(this.featurePackLocation()) ? ""
-						: (" -D" + this.featurePackLocation() + "="
+						: (" -D" + this.featurePackLocationPropertyName() + "="
 								+ this.featurePackLocation())))
 				+ ((Strings.isNullOrEmpty(this.cloudFeaturePackLocation()) ? ""
 						: (" -D" + this.cloudFeaturePackLocationPropertyName() + "="

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenShiftProvisionerTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenShiftProvisionerTestBase.java
@@ -53,7 +53,6 @@ import org.jboss.intersmash.provision.operator.model.infinispan.infinispan.Infin
 import org.jboss.intersmash.test.deployments.DeploymentsProvider;
 import org.jboss.intersmash.test.deployments.TestDeploymentProperties;
 import org.jboss.intersmash.test.deployments.WildflyDeploymentApplicationConfiguration;
-import org.jboss.intersmash.testsuite.IntersmashTestsuiteProperties;
 import org.jboss.intersmash.testsuite.junit5.categories.OpenShiftTest;
 import org.jboss.intersmash.util.CommandLineBasedKeystoreGenerator;
 import org.jboss.intersmash.util.openshift.WildflyOpenShiftUtils;


### PR DESCRIPTION
## Description

Fix WildflyDeploymentApplicationConfiguration, which is building Maven additional args wrongly in generateAdditionalMavenArgs

Resolves #207 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift