### PR TITLE
[issue-231] - Implement a feature to collect pod logs, which can be u…

### DIFF
--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollector.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollector.java
@@ -1,0 +1,93 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import lombok.NonNull;
+
+/**
+ * A class that collect pods' logs. It must be initialized via its {@link PodLogsCollectorBuilder} to provide a
+ * {@link NamespacedKubernetesClient} instance to connect to the cluster, and a collection of
+ * {@link Pod} instances which logs must be collected.
+ */
+public class PodLogsCollector {
+
+	private final NamespacedKubernetesClient client;
+	private final List<Pod> pods;
+
+	private final Predicate<Pod> podSelector;
+	private final Predicate<String> lineSelector;
+
+	/**
+	 * Initialize a new {@link PodLogsCollector} instance
+	 * @param client A {@link NamespacedKubernetesClient} instance, must be not null
+	 * @param pods A collection of {@link Pod} instances
+	 * @param podSelector A {@link Predicate<Pod>} to select a subset of pods to process
+	 * @param lineSelector A {@link Predicate<String>} to select a subset of log lines
+	 */
+	PodLogsCollector(@NonNull final NamespacedKubernetesClient client,
+			final List<Pod> pods, final Predicate<Pod> podSelector,
+			final Predicate<String> lineSelector) {
+		this.client = client;
+		this.pods = pods;
+		this.podSelector = podSelector;
+		this.lineSelector = lineSelector;
+	}
+
+	NamespacedKubernetesClient getClient() {
+		return client;
+	}
+
+	List<Pod> getPods() {
+		return pods;
+	}
+
+	Predicate<String> getLineSelector() {
+		return lineSelector;
+	}
+
+	Predicate<Pod> getPodSelector() {
+		return podSelector;
+	}
+
+	/**
+	 * Collect logs from each of the {@link Pod} instances which has been provided.
+	 * If a {@link Predicate<Pod>} has been provided to filter the target pods based on some criteria, then the collection
+	 * of target pods is matched against it.
+	 * Similarly, each of the collected pod log lines are filtered against a {@link Predicate<String>}, when it is
+	 * provided to the {@link PodLogsCollector} initialization.
+	 *
+	 * @return A collection of {@link PodLogsReport} instances, holding the log traces for the processed pods.
+	 */
+	public List<PodLogsReport> collect() {
+		if (pods == null || pods.isEmpty())
+			return List.of();
+		final List<PodLogsReport> podLogsReports = new ArrayList<>();
+		final List<Pod> selectedPods = podSelector == null ? pods
+				: pods.stream()
+						.filter(podSelector)
+						.collect(Collectors.toList());
+		selectedPods.stream().forEach(p -> {
+			// fetch all lines
+			final PodResource podResource = client.pods().withName(p.getMetadata().getName());
+			if (Objects.isNull(podResource)) {
+				throw new IllegalStateException("Target pod not found");
+			}
+			String podLog = podResource.getLog();
+			if (lineSelector != null) {
+				// funnel
+				podLog = Arrays.stream(podLog.split(System.lineSeparator())).filter(lineSelector)
+						.collect(Collectors.joining(System.lineSeparator()));
+			}
+			podLogsReports.add(new PodLogsReport(p, podLog));
+		});
+		return podLogsReports;
+	}
+}

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilder.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilder.java
@@ -1,0 +1,41 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+
+/**
+ * Class to build unique instances of {@link PodLogsCollector}
+ */
+public class PodLogsCollectorBuilder {
+	private NamespacedKubernetesClient client;
+	private List<Pod> pods;
+	private Predicate<Pod> podSelector;
+	private Predicate<String> lineSelector;
+
+	public PodLogsCollectorBuilder withClient(NamespacedKubernetesClient client) {
+		this.client = client;
+		return this;
+	}
+
+	public PodLogsCollectorBuilder withPods(List<Pod> pods) {
+		this.pods = pods;
+		return this;
+	}
+
+	public PodLogsCollectorBuilder withPodSelector(Predicate<Pod> podSelector) {
+		this.podSelector = podSelector;
+		return this;
+	}
+
+	public PodLogsCollectorBuilder withLineSelector(Predicate<String> lineSelector) {
+		this.lineSelector = lineSelector;
+		return this;
+	}
+
+	public PodLogsCollector build() {
+		return new PodLogsCollector(client, pods, podSelector, lineSelector);
+	}
+}

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsRelatedWaiterException.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsRelatedWaiterException.java
@@ -1,0 +1,26 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import java.util.List;
+
+import cz.xtf.core.waiting.WaiterException;
+import lombok.Getter;
+
+/**
+ * Represents a waiter exception which is related to the analysis of pod logs.
+ * Extends {@link WaiterException} to hold a collection of {@link PodLogsReport} instances.
+ */
+@Getter
+public class PodLogsRelatedWaiterException extends WaiterException {
+
+	private final List<PodLogsReport> podLogsReports;
+
+	public PodLogsRelatedWaiterException(List<PodLogsReport> podLogsReports) {
+		super();
+		this.podLogsReports = podLogsReports;
+	}
+
+	public PodLogsRelatedWaiterException(String message, List<PodLogsReport> podLogsReports) {
+		super(message);
+		this.podLogsReports = podLogsReports;
+	}
+}

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsReport.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsReport.java
@@ -1,0 +1,41 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import lombok.Getter;
+
+/**
+ * A POJO that stores a pod logs.
+ */
+@Getter
+public class PodLogsReport {
+
+	private static final String POD_LOG_REPORT_BOUNDARY = "\n\n\t==========\n\n";
+
+	private final Pod pod;
+	private final String podLog;
+
+	public PodLogsReport(Pod pod, String podLog) {
+		this.pod = pod;
+		this.podLog = podLog;
+	}
+
+	/**
+	 * Generate a human-readable text report of a collection of pod logs.
+	 * @param reports A collection of {@link PodLogsReport} instances, each holding a given pod logs
+	 * @return A  human-readable text report of a collection of pod logs.
+	 */
+	public static String generate(List<PodLogsReport> reports) {
+		if (!reports.isEmpty()) {
+			return reports.stream()
+					.map(podLogsReport -> String.format(
+							"Pod %s failed reporting the following log traces:\n%s\n",
+							podLogsReport.getPod().getMetadata().getName(),
+							podLogsReport.getPodLog()))
+					.collect(Collectors.joining(POD_LOG_REPORT_BOUNDARY));
+		}
+		return "";
+	}
+}

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilderTest.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilderTest.java
@@ -1,0 +1,73 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+
+/**
+ * Unit test that validates that {@link PodLogsCollectorBuilder} creates {@link PodLogsCollector} instances
+ * accordingly to a given configuration.
+ */
+class PodLogsCollectorBuilderTest {
+
+	/**
+	 * Validates a {@link PodLogsCollector} instance that is built out of a full configuration
+	 * @throws MalformedURLException The test uses a {@link URL} instance that represents the cluster master URL,
+	 * and this exception would be thrown if such url is not valid.
+	 */
+	@Test
+	void test_allPropertiesAreSet() throws MalformedURLException {
+		// Arrange
+		final String clusterUrl = "https://my-cluster:8443";
+		final NamespacedKubernetesClient client = Mockito.mock(NamespacedKubernetesClient.class);
+		Mockito.when(client.getMasterUrl()).thenReturn(new URL(clusterUrl));
+		final Pod aPod = new PodBuilder()
+				.withNewMetadata()
+				.withName("pod-0")
+				.endMetadata()
+				.build();
+		final Pod anotherPod = new PodBuilder()
+				.withNewMetadata()
+				.withName("pod-1")
+				.endMetadata()
+				.build();
+		final Predicate<Pod> podSelector = (pod) -> "pod-0".equals(pod.getMetadata().getName());
+		final Predicate<String> lineSelector = (line) -> line.contains(" FOO ");
+		// Act
+		PodLogsCollector podLogsCollector = new PodLogsCollectorBuilder()
+				.withClient(client)
+				.withPods(Arrays.asList(aPod, anotherPod))
+				.withPodSelector(podSelector)
+				.withLineSelector(lineSelector)
+				.build();
+		// Assert
+		final URL actualClientMasterUrl = podLogsCollector.getClient().getMasterUrl();
+		Assertions.assertNotNull(actualClientMasterUrl, "Null client Master URL value");
+		Assertions.assertEquals(new URL(clusterUrl), actualClientMasterUrl, "Unexpected client Master URL value");
+		final Predicate<Pod> actualPodSelector = podLogsCollector.getPodSelector();
+		Assertions.assertNotNull(actualPodSelector, "Null pod selector selector");
+		Assertions.assertEquals(podSelector.toString(), actualPodSelector.toString(), "Unexpected container status selector");
+		final List<Pod> actualPods = podLogsCollector.getPods();
+		Assertions.assertFalse(actualPods.isEmpty(), "Empty collection of collected pod logs");
+		Assertions.assertEquals(2, actualPods.size(), "Unexpected number of collected pod logs");
+		Assertions.assertTrue(actualPods.stream()
+				.anyMatch(p -> aPod.getMetadata().getName().equals(p.getMetadata().getName())),
+				"Cannot find the first pod in the collected pod logs");
+		Assertions.assertTrue(actualPods.stream()
+				.anyMatch(p -> anotherPod.getMetadata().getName().equals(p.getMetadata().getName())),
+				"Cannot find the second pod in the collected pod logs");
+		final Predicate<String> actualLineSelector = podLogsCollector.getLineSelector();
+		Assertions.assertNotNull(actualLineSelector, "Null line selector");
+		Assertions.assertEquals(lineSelector.toString(), actualLineSelector.toString(), "Unexpected line selector");
+	}
+}

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorTest.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorTest.java
@@ -1,0 +1,138 @@
+package org.jboss.intersmash.provision.util.k8s.log.collect;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+
+/**
+ * An integration test to validate the {@link PodLogsCollector} behavior.
+ *
+ * A cluster is mocked to let the collector work without require a proper e2e test, requiring an actual cluster.
+ */
+class PodLogsCollectorTest {
+
+	private static final String LOG_WITH_ERRORS = "\n" +
+			"12:00:01 INFO This is a line without any errors\n" +
+			"12:00:02 WARN We've got a warning here...\n" +
+			"12:00:03 ERROR And finally an error :(\n" +
+			"12:00:04 INFO Another clean line, though\n";
+
+	private static final String LOG_WITH_NO_ERRORS = "\n" +
+			"12:00:01 INFO All clean here...\n" +
+			"12:00:02 INFO Really!\n";
+
+	private static NamespacedKubernetesClient client = mock(NamespacedKubernetesClient.class);
+	private final static List<Pod> pods = new ArrayList<>();
+
+	/**
+	 * Mock a cluster that will be used to test {@link PodLogsCollector} behavior.
+	 * The cluster is made of two pods, one which has logs with ERRORS, and one which has clean log traces, just info
+	 * messages.
+	 */
+	@BeforeAll
+	static void setupCluster() {
+		final PodResource aPodResource = mock(PodResource.class);
+		final String aPodName = "pod-0";
+		final Pod aPod = mock(Pod.class);
+		final ObjectMeta aPodMetadata = new ObjectMetaBuilder()
+				.withName(aPodName)
+				.build();
+		final PodResource anotherPodResource = mock(PodResource.class);
+		final String anotherPodName = "pod-1";
+		final Pod anotherPod = mock(Pod.class);
+		final ObjectMeta anotherPodMetadata = new ObjectMetaBuilder()
+				.withName(anotherPodName)
+				.build();
+		final MixedOperation<Pod, PodList, PodResource> podsMixedOperation = mock(MixedOperation.class);
+
+		// identify target pods
+		pods.addAll(Arrays.asList(aPod, anotherPod));
+		when(client.pods()).thenReturn(podsMixedOperation);
+		when(client.pods().withName(aPodName)).thenReturn(aPodResource);
+		when(client.pods().withName(anotherPodName)).thenReturn(anotherPodResource);
+		when(aPod.getMetadata()).thenReturn(aPodMetadata);
+		when(aPodResource.getLog()).thenReturn(LOG_WITH_ERRORS);
+		when(anotherPod.getMetadata()).thenReturn(anotherPodMetadata);
+		when(anotherPodResource.getLog()).thenReturn(LOG_WITH_NO_ERRORS);
+	}
+
+	/**
+	 * Validate the collection of a failing pod logs.
+	 * Given the two pods in the cluster, a pod selector is provided for the collector to target only the first pod,
+	 * i.e. the one with error log traces.
+	 * A pod lines selector is provided as well, to only report the lines containing the "ERROR" marker.
+	 */
+	@Test
+	void test_selectPodByName_withLogErrors() {
+		// Arrange
+		// build a pod log collector
+		final PodLogsCollector podLogsCollector = new PodLogsCollectorBuilder()
+				.withClient(client)
+				.withPods(pods)
+				// filter: only pod with name == "pod-0"
+				.withPodSelector(p -> "pod-0".equals(p.getMetadata().getName()))
+				// filter server ERROR log lines
+				.withLineSelector((line) -> line.contains(" ERROR "))
+				.build();
+		// Act
+		final List<PodLogsReport> reports = podLogsCollector.collect();
+		final String report = PodLogsReport.generate(reports);
+		// Assert
+		Assertions.assertEquals(1, reports.size(), "Unexpected number of collected pod logs");
+		final PodLogsReport actualReport = reports.get(0);
+		Assertions.assertNotNull(actualReport.getPod(), "Unexpected null pod");
+		Assertions.assertNotNull(actualReport.getPodLog(), "Unexpected null pod log");
+		Assertions.assertTrue(report.contains("12:00:03 ERROR And finally an error :("));
+	}
+
+	/**
+	 * Validate the collection of both pods' logs.
+	 * No pod selector is provided, nor a lines selector is provided as well, so both the pods' logs should be reported
+	 * unfiltered.
+	 */
+	@Test
+	void test_noPodSelector_noLineSelector() {
+		// Arrange
+		// build a pod log collector
+		final PodLogsCollector podLogsCollector = new PodLogsCollectorBuilder()
+				.withClient(client)
+				.withPods(pods)
+				.build();
+		// Act
+		final List<PodLogsReport> reports = podLogsCollector.collect();
+		final String report = PodLogsReport.generate(reports);
+		// Assert
+		Assertions.assertEquals(2, reports.size(), "Unexpected number of collected pod logs");
+		final PodLogsReport aPodReport = reports.stream()
+				.filter(r -> "pod-0".equals(r.getPod().getMetadata().getName()))
+				.findFirst()
+				.orElse(null);
+		Assertions.assertNotNull(aPodReport, "Unexpected null pod report");
+		Assertions.assertNotNull(aPodReport.getPod(), "Unexpected null pod");
+		Assertions.assertNotNull(aPodReport.getPodLog(), "Unexpected null pod log");
+		Assertions.assertTrue(report.contains(LOG_WITH_ERRORS));
+		final PodLogsReport anotherPodReport = reports.stream()
+				.filter(r -> "pod-1".equals(r.getPod().getMetadata().getName()))
+				.findFirst()
+				.orElse(null);
+		Assertions.assertNotNull(anotherPodReport, "Unexpected null pod report");
+		Assertions.assertNotNull(anotherPodReport.getPod(), "Unexpected null pod");
+		Assertions.assertNotNull(anotherPodReport.getPodLog(), "Unexpected null pod log");
+		Assertions.assertTrue(report.contains(LOG_WITH_NO_ERRORS));
+	}
+}


### PR DESCRIPTION
## Description
Here we're proposing a simple API to collect pod logs. The implementation allows the user to provide a set of target pods, a selector which can be used to funnel them based on certain conditions, and a filter to restrict the set of log lines which should be reported.

The API can be used in conjunction with `Waiter` implementations, so that - for example - a restarted replica logs can be collected and pumped into the STDOUT to report relevant data once the `Waiter` hits the timeout.

A unit test for the builder and an integration test for the collector itself are provided within the PR. 

Resolves #231 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
