### PR TITLE
Replace revelc plugins with the Spotless Maven plugin

### DIFF
--- a/.github/workflows/kubernetes-e2e.yml
+++ b/.github/workflows/kubernetes-e2e.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - 'ide-config/**'
       - '**.md'
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,3 @@ mvn process-sources
 
 to format your code before sending it for revision.
 CI jobs will run the checks (`mvn formatter:validate impsort:check`) and fail in case of wrong formatting.
-
-To set up your IDE to comply with the formatting, please get the 
-[eclipse-format.xml](./ide-config/eclipse-format.xml) configuration file and follow [Eclipse Code Formatter instructions](https://github.com/krasa/EclipseCodeFormatter#instructions).

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,10 +11,6 @@
 
     <name>Intersmash Core</name>
 
-    <properties>
-        <formatting-style-base-directory>${project.parent.basedir}/ide-config</formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>dev.failsafe</groupId>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="15">
+    <profile kind="CodeFormatterProfile" name="Quarkus" version="15">
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="160"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="128"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+    </profile>
+</profiles>

--- a/examples/wildfly-keycloak-saml-adapter/pom.xml
+++ b/examples/wildfly-keycloak-saml-adapter/pom.xml
@@ -16,7 +16,6 @@
     <name>Intersmash Demos : (Wildfly): Wildfly with Keycloak SAML Adapter</name>
 
     <properties>
-        <formatting-style-base-directory>${project.parent.parent.basedir}/ide-config</formatting-style-base-directory>
         <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
         <!-- Wildfly default version -->
         <version.wildfly-server>35.0.0.Final</version.wildfly-server>

--- a/examples/ws-bootable-jar-example/jaxws/pom.xml
+++ b/examples/ws-bootable-jar-example/jaxws/pom.xml
@@ -41,7 +41,6 @@
 
 
     <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
         <version.jbossws-cxf>6.2.0.Final</version.jbossws-cxf>
     </properties>
 

--- a/examples/wstrust/service/pom.xml
+++ b/examples/wstrust/service/pom.xml
@@ -40,8 +40,6 @@
     <name>Intersmash Demos : (Wildfly): Webservices Trust Example (service)</name>
 
     <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config
-        </formatting-style-base-directory>
         <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
 
         <version.wildfly.feature-pack>35.0.0.Final</version.wildfly.feature-pack>

--- a/examples/wstrust/shared/pom.xml
+++ b/examples/wstrust/shared/pom.xml
@@ -38,10 +38,6 @@
 
     <name>Intersmash Demos : (Wildfly): Webservices Trust Example (shared) </name>
 
-    <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.ws.cxf</groupId>

--- a/examples/wstrust/sts/pom.xml
+++ b/examples/wstrust/sts/pom.xml
@@ -40,8 +40,6 @@
     <name>Intersmash Demos : (Wildfly): Webservices Trust Example (sts)</name>
 
     <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config
-        </formatting-style-base-directory>
         <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
 
         <version.wildfly.feature-pack>35.0.0.Final</version.wildfly.feature-pack>

--- a/examples/wstrust/test/pom.xml
+++ b/examples/wstrust/test/pom.xml
@@ -37,12 +37,6 @@
     <artifactId>wstrust-test</artifactId>
     <name>Intersmash Demos : (Wildfly): Webservices Trust Example (test)</name>
 
-
-    <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config
-        </formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.intersmash.examples</groupId>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -11,10 +11,6 @@
 
     <name>Intersmash Kubernetes client</name>
 
-    <properties>
-        <formatting-style-base-directory>${project.parent.basedir}/ide-config</formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/KubernetesConfig.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/KubernetesConfig.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s;
 
 import java.nio.file.Paths;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/Kubernetes.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/Kubernetes.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client;
 
 import java.io.IOException;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/Kuberneteses.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/Kuberneteses.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client;
 
 import java.io.File;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/NamespaceManager.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/NamespaceManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client;
 
 import java.util.HashMap;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/TestCaseContext.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/TestCaseContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client;
 
 public class TestCaseContext {

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/ClusterVersionBasedKubernetesClientBinaryPathResolver.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/ClusterVersionBasedKubernetesClientBinaryPathResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import java.io.IOException;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/ConfigurationBasedKubernetesClientBinaryPathResolver.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/ConfigurationBasedKubernetesClientBinaryPathResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import org.jboss.intersmash.k8s.KubernetesConfig;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinary.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinary.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import java.lang.reflect.Type;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManager.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import java.io.File;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManagerFactory.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManagerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import java.util.List;

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryPathResolver.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryPathResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 /**

--- a/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/junit5/KubernetesNamespaceCreator.java
+++ b/kubernetes-client/src/main/java/org/jboss/intersmash/k8s/junit5/KubernetesNamespaceCreator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.junit5;
 
 import java.util.Arrays;

--- a/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/ClusterVersionBasedKubernetesClientBinaryPathResolverTest.java
+++ b/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/ClusterVersionBasedKubernetesClientBinaryPathResolverTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import java.io.IOException;

--- a/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/ConfigurationBasedKubernetesClientBinaryPathResolverTest.java
+++ b/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/ConfigurationBasedKubernetesClientBinaryPathResolverTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import org.junit.jupiter.api.Assertions;

--- a/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManagerFactoryTest.java
+++ b/kubernetes-client/src/test/java/org/jboss/intersmash/k8s/client/binary/KubernetesClientBinaryManagerFactoryTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.k8s.client.binary;
 
 import org.junit.jupiter.api.Assertions;

--- a/pom.xml
+++ b/pom.xml
@@ -627,8 +627,12 @@
                     <!-- define a language-specific format -->
                     <java>
                         <removeUnusedImports/>
-                        <importOrder/>
-                        <eclipse/>
+                        <importOrder>
+                            <order>jakarta,java,javax,org,com</order>
+                        </importOrder>
+                        <eclipse>
+                            <file>eclipse-formatter.xml</file>
+                        </eclipse>
                         <!-- make sure every file has the following copyright header.
                           optionally, Spotless can set copyright years by digging
                           through git history (see "license" section below) -->

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,9 @@
                 <configuration>
                     <!-- define a language-specific format -->
                     <java>
+                        <removeUnusedImports/>
+                        <importOrder/>
+                        <eclipse/>
                         <!-- make sure every file has the following copyright header.
                           optionally, Spotless can set copyright years by digging
                           through git history (see "license" section below) -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <formatting-style-base-directory>${project.basedir}/ide-config</formatting-style-base-directory>
-        <formatting-style-file>eclipse-format.xml</formatting-style-file>
-
         <!--
             Using XTF snapshot in order to include fixes in:
             https://github.com/xtf-cz/xtf/pull/532
@@ -64,7 +61,6 @@
         <version.mockito.core>4.9.0</version.mockito.core>
         <version.logback>1.2.13</version.logback>
         <version.org.slf4j>1.7.30</version.org.slf4j>
-        <version.ide-config>1.1</version.ide-config>
         <version.io.strimzi-api>0.38.0</version.io.strimzi-api>
         <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
         <version.io.fabric8>6.8.1</version.io.fabric8>
@@ -76,8 +72,6 @@
         -->
         <version.intersmash.activemq.operators>v1.0.11</version.intersmash.activemq.operators>
 
-        <version.impsort-maven-plugin>1.8.0</version.impsort-maven-plugin>
-        <version.formatter-maven-plugin>2.21.0</version.formatter-maven-plugin>
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-checkstyle-plugin>3.1.1</version.maven-checkstyle-plugin>
         <version.maven-clean-plugin>3.1.0</version.maven-clean-plugin>
@@ -485,16 +479,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>net.revelc.code.formatter</groupId>
-                    <artifactId>formatter-maven-plugin</artifactId>
-                    <version>${version.formatter-maven-plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>net.revelc.code</groupId>
-                    <artifactId>impsort-maven-plugin</artifactId>
-                    <version>${version.impsort-maven-plugin}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>${version.maven-clean-plugin}</version>
@@ -603,41 +587,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <configuration>
-                    <configFile>${formatting-style-base-directory}/${formatting-style-file}</configFile>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>format</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>net.revelc.code</groupId>
-                <artifactId>impsort-maven-plugin</artifactId>
-                <configuration>
-                    <groups>jakarta.,java.,javax.,org.,com.</groups>
-                    <staticGroups>*</staticGroups>
-                    <removeUnused>true</removeUnused>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sort-imports</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>sort</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/provisioners/pom.xml
+++ b/provisioners/pom.xml
@@ -14,8 +14,6 @@
     <properties>
         <logDirectory>${basedir}/log/test-logs</logDirectory>
         <version.org.keycloak.keycloak-admin-client>26.0.3</version.org.keycloak.keycloak-admin-client>
-
-        <formatting-style-base-directory>${project.parent.basedir}/ide-config</formatting-style-base-directory>
     </properties>
 
     <dependencies>

--- a/provisioners/src/main/java/org/jboss/intersmash/application/openshift/DBTemplateOpenShiftApplication.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/application/openshift/DBTemplateOpenShiftApplication.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.application.openshift;
 
 import java.util.Collections;

--- a/provisioners/src/main/java/org/jboss/intersmash/application/openshift/PostgreSQLTemplateOpenShiftApplication.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/application/openshift/PostgreSQLTemplateOpenShiftApplication.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.application.openshift;
 
 import org.jboss.intersmash.application.openshift.template.PostgreSQLTemplate;

--- a/provisioners/src/main/java/org/jboss/intersmash/application/openshift/RhSsoTemplateOpenShiftApplication.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/application/openshift/RhSsoTemplateOpenShiftApplication.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.application.openshift;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/application/openshift/template/PostgreSQLTemplate.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/application/openshift/template/PostgreSQLTemplate.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.application.openshift.template;
 
 import org.jboss.intersmash.provision.openshift.template.OpenShiftTemplate;

--- a/provisioners/src/main/java/org/jboss/intersmash/application/openshift/template/RhSsoTemplate.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/application/openshift/template/RhSsoTemplate.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.application.openshift.template;
 
 import java.util.HashMap;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/HelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/HelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm;
 
 import java.io.IOException;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/Image.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/Image.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm;
 
 import java.util.List;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/WildFlyHelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/WildFlyHelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/WildflyHelmChartRelease.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/WildflyHelmChartRelease.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly;
 
 import java.util.LinkedHashSet;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/eap8/Eap8HelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/eap8/Eap8HelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly.eap8;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/eap81/Eap81HelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/eap81/Eap81HelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly.eap81;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/xp5/EapXp5HelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/xp5/EapXp5HelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly.xp5;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/xp6/EapXp6HelmChartReleaseAdapter.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/helm/wildfly/xp6/EapXp6HelmChartReleaseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly.xp6;
 
 import java.nio.file.Path;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/BootableJarImageOpenShiftProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/BootableJarImageOpenShiftProvisioner.java
@@ -145,9 +145,9 @@ public abstract class BootableJarImageOpenShiftProvisioner
 			} else if (archiveFile.isFile()) {
 				/*
 				  S2I Binary build which takes as input a bootable Jar;
-
+				
 				  This kind of build corresponds to the following workflow:
-
+				
 						oc new-build --name=wildfly-build-from-bootable-jar \
 							--labels=intersmash.app=wildfly-test-app \
 							--binary=true \
@@ -155,11 +155,11 @@ public abstract class BootableJarImageOpenShiftProvisioner
 							--env=ADMIN_USERNAME=admin \
 							--env=ADMIN_PASSWORD=pass.1234 \
 							--image=registry.redhat.io/ubi8/openjdk-11
-
+				
 						oc start-build wildfly-build-from-bootable-jar \
 							--from-file=bootable-openshift.jar \
 							--follow
-
+				
 						oc new-app wildfly-build-from-bootable-jar
 				 */
 				bootableJarBuild = new BinaryBuildFromFile(

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/Eap7LegacyS2iBuildTemplateProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/Eap7LegacyS2iBuildTemplateProvisioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import java.io.IOException;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/Eap7LegacyS2iBuildTemplateProvisionerFactory.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/Eap7LegacyS2iBuildTemplateProvisionerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import org.jboss.intersmash.application.Application;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/PostgreSQLTemplateOpenShiftProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/PostgreSQLTemplateOpenShiftProvisioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import java.util.HashMap;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/PostgreSQLTemplateOpenShiftProvisionerFactory.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/PostgreSQLTemplateOpenShiftProvisionerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import org.jboss.intersmash.application.Application;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoTemplateOpenShiftProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoTemplateOpenShiftProvisioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import java.io.IOException;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoTemplateOpenShiftProvisionerFactory.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoTemplateOpenShiftProvisionerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift;
 
 import org.jboss.intersmash.application.Application;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/WildflyImageOpenShiftProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/WildflyImageOpenShiftProvisioner.java
@@ -127,12 +127,12 @@ public class WildflyImageOpenShiftProvisioner implements OpenShiftProvisioner<Wi
 			if (archiveFile.isDirectory()) {
 				/*
 				  S2I Binary build which takes as input the source code of a maven project located on the local filesystem;
-
+				
 				  This kind of build corresponds to the following workflows:
-
+				
 				  1. "Maven Project": The maven build is run inside the builder image,
 				     E.g.:
-
+				
 						oc new-build --name=wildfly-build-from-source-code \
 							--labels=intersmash.app=wildfly-test-app \
 							--binary=true \
@@ -141,21 +141,21 @@ public class WildflyImageOpenShiftProvisioner implements OpenShiftProvisioner<Wi
 							--env=ADMIN_PASSWORD=pass.1234 \
 							--env=MAVEN_ARGS_APPEND="-Dwildfly.ee-feature-pack.location=org.wildfly:wildfly-galleon-pack:27.0.0.Alpha4 -Dwildfly.cloud-feature-pack.location=org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha4" \
 							--image=quay.io/wildfly/wildfly-s2i-jdk11:latest
-
+				
 						oc start-build wildfly-build-from-source-code \
 							--from-dir=/some-path/intersmash-tools/intersmash-tools-provisioners/src/test/resources/apps/openshift-jakarta-sample \
 							--follow
-
+				
 						oc new-app wildfly-build-from-source-code
-
+				
 				  2. "target/server": The maven build is run on the local machine and then, server and application are uploaded to the builder image,
 				  	 E.g.:
-
+				
 				  		cd /path/intersmash/intersmash-tools/intersmash-tools-provisioners/src/test/resources/apps/openshift-jakarta-sample/target/server
 						mvn install -P openshift \
 							-Dwildfly.ee-feature-pack.location=org.wildfly:wildfly-galleon-pack:27.0.0.Alpha4 \
 							-Dwildfly.cloud-feature-pack.location=org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha4
-
+				
 						oc new-build --name=wildfly-build-from-server \
 							--labels=intersmash.app=wildfly-test-app \
 							--binary=true \
@@ -163,11 +163,11 @@ public class WildflyImageOpenShiftProvisioner implements OpenShiftProvisioner<Wi
 							--env=ADMIN_USERNAME=admin \
 							--env=ADMIN_PASSWORD=pass.1234 \
 							--image=quay.io/wildfly/wildfly-s2i-jdk11:latest
-
+				
 						oc start-build wildfly-build-from-server \
 							--from-dir=./target/server \
 							--follow
-
+				
 						oc new-app wildfly-build-from-server
 				 */
 				BinaryBuild binaryBuild;
@@ -186,16 +186,16 @@ public class WildflyImageOpenShiftProvisioner implements OpenShiftProvisioner<Wi
 			} else if (archiveFile.isFile()) {
 				/*
 				  Legacy S2I Binary build which takes as input an already built artifact e.g. WAR file;
-
+				
 				  Note that WILDFLY images do not contain the server anymore;
-
+				
 				  This scenario is probably to be pruned: now, if the build of th maven project happens outside
 				  openshift, you start a binary build "--from-dir" using the "target/server" folder;
-
+				
 				  This workflow is just preserved to support legacy builds where no server is provisioned because the
 				  maven project isn't configured to use the new "wildfly-maven-plugin";
 				  E.g.
-
+				
 					oc new-build --name=wildfly-build-from-war \
 						--labels=intersmash.app=wildfly-test-app \
 						--binary=true \
@@ -205,11 +205,11 @@ public class WildflyImageOpenShiftProvisioner implements OpenShiftProvisioner<Wi
 						--env=GALLEON_PROVISION_FEATURE_PACKS="org.wildfly:wildfly-galleon-pack:27.0.0.Alpha4,org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha4" \
 						--env=GALLEON_PROVISION_LAYERS=cloud-server \
 						--image=quay.io/wildfly/wildfly-s2i-jdk11:latest
-
+				
 					oc start-build wildfly-build-from-war \
 						--from-file=/some-path/intersmash/intersmash-tools/intersmash-tools-provisioners/src/test/resources/apps/openshift-jakarta-sample/target/ROOT.war \
 						--follow
-
+				
 					oc new-app wildfly-build-from-war
 				 */
 				BinaryBuildFromFile wildflyBuild = new BinaryBuildFromFile(

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/template/RhSsoTemplateProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/template/RhSsoTemplateProvisioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.openshift.template;
 
 import java.io.IOException;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/HyperfoilOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/HyperfoilOperatorProvisioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.operator;
 
 import java.util.List;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/hyperfoil/client/v05/HyperfoilApi.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/hyperfoil/client/v05/HyperfoilApi.java
@@ -81,7 +81,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call addBenchmarkCall(String ifMatch, String storedFilesBenchmark, File body, final ApiCallback _callback)
 			throws ApiException {
@@ -156,7 +156,7 @@ public class HyperfoilApi {
 	 * @param body Benchmark definition. (optional)
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public void addBenchmark(String ifMatch, String storedFilesBenchmark, File body) throws ApiException {
 		addBenchmarkWithHttpInfo(ifMatch, storedFilesBenchmark, body);
@@ -171,7 +171,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Void&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Void> addBenchmarkWithHttpInfo(String ifMatch, String storedFilesBenchmark, File body)
 			throws ApiException {
@@ -189,7 +189,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call addBenchmarkAsync(String ifMatch, String storedFilesBenchmark, File body,
 			final ApiCallback<Void> _callback) throws ApiException {
@@ -206,7 +206,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call agentCpuCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -275,7 +275,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object agentCpu(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = agentCpuWithHttpInfo(runId);
@@ -289,7 +289,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> agentCpuWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = agentCpuValidateBeforeCall(runId, null);
@@ -306,7 +306,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call agentCpuAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -325,7 +325,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call createReportCall(String runId, String source, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -400,7 +400,7 @@ public class HyperfoilApi {
 	 * @return String
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public String createReport(String runId, String source) throws ApiException {
 		ApiResponse<String> localVarResp = createReportWithHttpInfo(runId, source);
@@ -415,7 +415,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<String> createReportWithHttpInfo(String runId, String source) throws ApiException {
 		okhttp3.Call localVarCall = createReportValidateBeforeCall(runId, source, null);
@@ -433,7 +433,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call createReportAsync(String runId, String source, final ApiCallback<String> _callback)
 			throws ApiException {
@@ -454,7 +454,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAgentLogCall(String agent, Integer offset, String ifMatch, final ApiCallback _callback)
 			throws ApiException {
@@ -535,7 +535,7 @@ public class HyperfoilApi {
 	 * @return String
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public String getAgentLog(String agent, Integer offset, String ifMatch) throws ApiException {
 		ApiResponse<String> localVarResp = getAgentLogWithHttpInfo(agent, offset, ifMatch);
@@ -551,7 +551,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<String> getAgentLogWithHttpInfo(String agent, Integer offset, String ifMatch) throws ApiException {
 		okhttp3.Call localVarCall = getAgentLogValidateBeforeCall(agent, offset, ifMatch, null);
@@ -570,7 +570,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAgentLogAsync(String agent, Integer offset, String ifMatch, final ApiCallback<String> _callback)
 			throws ApiException {
@@ -589,7 +589,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -658,7 +658,7 @@ public class HyperfoilApi {
 	 * @return File
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public File getAllStats(String runId) throws ApiException {
 		ApiResponse<File> localVarResp = getAllStatsWithHttpInfo(runId);
@@ -672,7 +672,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;File&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<File> getAllStatsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getAllStatsValidateBeforeCall(runId, null);
@@ -689,7 +689,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsAsync(String runId, final ApiCallback<File> _callback) throws ApiException {
 
@@ -707,7 +707,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsCsvCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -776,7 +776,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getAllStatsCsv(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getAllStatsCsvWithHttpInfo(runId);
@@ -790,7 +790,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getAllStatsCsvWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getAllStatsCsvValidateBeforeCall(runId, null);
@@ -807,7 +807,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsCsvAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -825,7 +825,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsJsonCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -894,7 +894,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getAllStatsJson(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getAllStatsJsonWithHttpInfo(runId);
@@ -908,7 +908,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getAllStatsJsonWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getAllStatsJsonValidateBeforeCall(runId, null);
@@ -925,7 +925,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getAllStatsJsonAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -943,7 +943,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkCall(String name, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1012,7 +1012,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getBenchmark(String name) throws ApiException {
 		ApiResponse<Object> localVarResp = getBenchmarkWithHttpInfo(name);
@@ -1026,7 +1026,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getBenchmarkWithHttpInfo(String name) throws ApiException {
 		okhttp3.Call localVarCall = getBenchmarkValidateBeforeCall(name, null);
@@ -1043,7 +1043,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkAsync(String name, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -1061,7 +1061,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkFilesCall(String name, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1130,7 +1130,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getBenchmarkFiles(String name) throws ApiException {
 		ApiResponse<Object> localVarResp = getBenchmarkFilesWithHttpInfo(name);
@@ -1144,7 +1144,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getBenchmarkFilesWithHttpInfo(String name) throws ApiException {
 		okhttp3.Call localVarCall = getBenchmarkFilesValidateBeforeCall(name, null);
@@ -1161,7 +1161,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkFilesAsync(String name, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -1179,7 +1179,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkForRunCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1248,7 +1248,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getBenchmarkForRun(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getBenchmarkForRunWithHttpInfo(runId);
@@ -1262,7 +1262,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getBenchmarkForRunWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getBenchmarkForRunValidateBeforeCall(runId, null);
@@ -1279,7 +1279,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkForRunAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -1299,7 +1299,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkStructureCall(String name, Integer maxCollectionSize, List<String> templateParam,
 			final ApiCallback _callback) throws ApiException {
@@ -1380,7 +1380,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getBenchmarkStructure(String name, Integer maxCollectionSize, List<String> templateParam)
 			throws ApiException {
@@ -1397,7 +1397,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getBenchmarkStructureWithHttpInfo(String name, Integer maxCollectionSize,
 			List<String> templateParam) throws ApiException {
@@ -1417,7 +1417,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getBenchmarkStructureAsync(String name, Integer maxCollectionSize, List<String> templateParam,
 			final ApiCallback<Object> _callback) throws ApiException {
@@ -1437,7 +1437,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getControllerLogCall(Integer offset, String ifMatch, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1510,7 +1510,7 @@ public class HyperfoilApi {
 	 * @return String
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public String getControllerLog(Integer offset, String ifMatch) throws ApiException {
 		ApiResponse<String> localVarResp = getControllerLogWithHttpInfo(offset, ifMatch);
@@ -1525,7 +1525,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<String> getControllerLogWithHttpInfo(Integer offset, String ifMatch) throws ApiException {
 		okhttp3.Call localVarCall = getControllerLogValidateBeforeCall(offset, ifMatch, null);
@@ -1543,7 +1543,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getControllerLogAsync(Integer offset, String ifMatch, final ApiCallback<String> _callback)
 			throws ApiException {
@@ -1565,7 +1565,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getHistogramStatsCall(String runId, String phase, Integer stepId, String metric,
 			final ApiCallback _callback) throws ApiException {
@@ -1666,7 +1666,7 @@ public class HyperfoilApi {
 	 * @return List&lt;Histogram&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public List<Histogram> getHistogramStats(String runId, String phase, Integer stepId, String metric) throws ApiException {
 		ApiResponse<List<Histogram>> localVarResp = getHistogramStatsWithHttpInfo(runId, phase, stepId, metric);
@@ -1683,7 +1683,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;List&lt;Histogram&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<List<Histogram>> getHistogramStatsWithHttpInfo(String runId, String phase, Integer stepId, String metric)
 			throws ApiException {
@@ -1704,7 +1704,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getHistogramStatsAsync(String runId, String phase, Integer stepId, String metric,
 			final ApiCallback<List<Histogram>> _callback) throws ApiException {
@@ -1723,7 +1723,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentConnectionsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1792,7 +1792,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getRecentConnections(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getRecentConnectionsWithHttpInfo(runId);
@@ -1806,7 +1806,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getRecentConnectionsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getRecentConnectionsValidateBeforeCall(runId, null);
@@ -1823,7 +1823,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentConnectionsAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -1841,7 +1841,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentSessionsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -1910,7 +1910,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getRecentSessions(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getRecentSessionsWithHttpInfo(runId);
@@ -1924,7 +1924,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getRecentSessionsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getRecentSessionsValidateBeforeCall(runId, null);
@@ -1941,7 +1941,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentSessionsAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -1959,7 +1959,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentStatsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2028,7 +2028,7 @@ public class HyperfoilApi {
 	 * @return RequestStatisticsResponse
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public RequestStatisticsResponse getRecentStats(String runId) throws ApiException {
 		ApiResponse<RequestStatisticsResponse> localVarResp = getRecentStatsWithHttpInfo(runId);
@@ -2042,7 +2042,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;RequestStatisticsResponse&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<RequestStatisticsResponse> getRecentStatsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getRecentStatsValidateBeforeCall(runId, null);
@@ -2059,7 +2059,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRecentStatsAsync(String runId, final ApiCallback<RequestStatisticsResponse> _callback)
 			throws ApiException {
@@ -2078,7 +2078,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRunCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2147,7 +2147,7 @@ public class HyperfoilApi {
 	 * @return Run
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Run getRun(String runId) throws ApiException {
 		ApiResponse<Run> localVarResp = getRunWithHttpInfo(runId);
@@ -2161,7 +2161,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Run&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Run> getRunWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getRunValidateBeforeCall(runId, null);
@@ -2178,7 +2178,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRunAsync(String runId, final ApiCallback<Run> _callback) throws ApiException {
 
@@ -2197,7 +2197,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRunFileCall(String runId, String _file, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2277,7 +2277,7 @@ public class HyperfoilApi {
 	 * @return File
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public File getRunFile(String runId, String _file) throws ApiException {
 		ApiResponse<File> localVarResp = getRunFileWithHttpInfo(runId, _file);
@@ -2292,7 +2292,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;File&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<File> getRunFileWithHttpInfo(String runId, String _file) throws ApiException {
 		okhttp3.Call localVarCall = getRunFileValidateBeforeCall(runId, _file, null);
@@ -2310,7 +2310,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getRunFileAsync(String runId, String _file, final ApiCallback<File> _callback) throws ApiException {
 
@@ -2327,7 +2327,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTokenCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2388,7 +2388,7 @@ public class HyperfoilApi {
 	 * Returns authorization token that can be used instead of credentials with Basic Auth.
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public void getToken() throws ApiException {
 		getTokenWithHttpInfo();
@@ -2400,7 +2400,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Void&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Void> getTokenWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = getTokenValidateBeforeCall(null);
@@ -2414,7 +2414,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTokenAsync(final ApiCallback<Void> _callback) throws ApiException {
 
@@ -2430,7 +2430,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalConnectionsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2499,7 +2499,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getTotalConnections(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getTotalConnectionsWithHttpInfo(runId);
@@ -2513,7 +2513,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getTotalConnectionsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getTotalConnectionsValidateBeforeCall(runId, null);
@@ -2530,7 +2530,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalConnectionsAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -2548,7 +2548,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalSessionsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2617,7 +2617,7 @@ public class HyperfoilApi {
 	 * @return Object
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Object getTotalSessions(String runId) throws ApiException {
 		ApiResponse<Object> localVarResp = getTotalSessionsWithHttpInfo(runId);
@@ -2631,7 +2631,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Object&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Object> getTotalSessionsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getTotalSessionsValidateBeforeCall(runId, null);
@@ -2648,7 +2648,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalSessionsAsync(String runId, final ApiCallback<Object> _callback) throws ApiException {
 
@@ -2666,7 +2666,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalStatsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2735,7 +2735,7 @@ public class HyperfoilApi {
 	 * @return RequestStatisticsResponse
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public RequestStatisticsResponse getTotalStats(String runId) throws ApiException {
 		ApiResponse<RequestStatisticsResponse> localVarResp = getTotalStatsWithHttpInfo(runId);
@@ -2749,7 +2749,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;RequestStatisticsResponse&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<RequestStatisticsResponse> getTotalStatsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = getTotalStatsValidateBeforeCall(runId, null);
@@ -2766,7 +2766,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getTotalStatsAsync(String runId, final ApiCallback<RequestStatisticsResponse> _callback)
 			throws ApiException {
@@ -2784,7 +2784,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getVersionCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2846,7 +2846,7 @@ public class HyperfoilApi {
 	 * @return Version
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Version getVersion() throws ApiException {
 		ApiResponse<Version> localVarResp = getVersionWithHttpInfo();
@@ -2859,7 +2859,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Version&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Version> getVersionWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = getVersionValidateBeforeCall(null);
@@ -2875,7 +2875,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call getVersionAsync(final ApiCallback<Version> _callback) throws ApiException {
 
@@ -2893,7 +2893,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call killRunCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -2961,7 +2961,7 @@ public class HyperfoilApi {
 	 * @param runId  (required)
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public void killRun(String runId) throws ApiException {
 		killRunWithHttpInfo(runId);
@@ -2974,7 +2974,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Void&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Void> killRunWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = killRunValidateBeforeCall(runId, null);
@@ -2989,7 +2989,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call killRunAsync(String runId, final ApiCallback<Void> _callback) throws ApiException {
 
@@ -3004,7 +3004,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listAgentsCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3066,7 +3066,7 @@ public class HyperfoilApi {
 	 * @return List&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public List<String> listAgents() throws ApiException {
 		ApiResponse<List<String>> localVarResp = listAgentsWithHttpInfo();
@@ -3079,7 +3079,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;List&lt;String&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<List<String>> listAgentsWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = listAgentsValidateBeforeCall(null);
@@ -3095,7 +3095,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listAgentsAsync(final ApiCallback<List<String>> _callback) throws ApiException {
 
@@ -3112,7 +3112,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listBenchmarksCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3174,7 +3174,7 @@ public class HyperfoilApi {
 	 * @return List&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public List<String> listBenchmarks() throws ApiException {
 		ApiResponse<List<String>> localVarResp = listBenchmarksWithHttpInfo();
@@ -3187,7 +3187,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;List&lt;String&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<List<String>> listBenchmarksWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = listBenchmarksValidateBeforeCall(null);
@@ -3203,7 +3203,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listBenchmarksAsync(final ApiCallback<List<String>> _callback) throws ApiException {
 
@@ -3221,7 +3221,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listConnectionsCall(String runId, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3290,7 +3290,7 @@ public class HyperfoilApi {
 	 * @return String
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public String listConnections(String runId) throws ApiException {
 		ApiResponse<String> localVarResp = listConnectionsWithHttpInfo(runId);
@@ -3304,7 +3304,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<String> listConnectionsWithHttpInfo(String runId) throws ApiException {
 		okhttp3.Call localVarCall = listConnectionsValidateBeforeCall(runId, null);
@@ -3321,7 +3321,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listConnectionsAsync(String runId, final ApiCallback<String> _callback) throws ApiException {
 
@@ -3339,7 +3339,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listRunsCall(Boolean details, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3406,7 +3406,7 @@ public class HyperfoilApi {
 	 * @return Run
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Run listRuns(Boolean details) throws ApiException {
 		ApiResponse<Run> localVarResp = listRunsWithHttpInfo(details);
@@ -3420,7 +3420,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Run&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Run> listRunsWithHttpInfo(Boolean details) throws ApiException {
 		okhttp3.Call localVarCall = listRunsValidateBeforeCall(details, null);
@@ -3437,7 +3437,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listRunsAsync(Boolean details, final ApiCallback<Run> _callback) throws ApiException {
 
@@ -3456,7 +3456,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listSessionsCall(String runId, Boolean inactive, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3531,7 +3531,7 @@ public class HyperfoilApi {
 	 * @return String
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public String listSessions(String runId, Boolean inactive) throws ApiException {
 		ApiResponse<String> localVarResp = listSessionsWithHttpInfo(runId, inactive);
@@ -3546,7 +3546,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<String> listSessionsWithHttpInfo(String runId, Boolean inactive) throws ApiException {
 		okhttp3.Call localVarCall = listSessionsValidateBeforeCall(runId, inactive, null);
@@ -3564,7 +3564,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listSessionsAsync(String runId, Boolean inactive, final ApiCallback<String> _callback)
 			throws ApiException {
@@ -3582,7 +3582,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listTemplatesCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3644,7 +3644,7 @@ public class HyperfoilApi {
 	 * @return List&lt;String&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public List<String> listTemplates() throws ApiException {
 		ApiResponse<List<String>> localVarResp = listTemplatesWithHttpInfo();
@@ -3657,7 +3657,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;List&lt;String&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<List<String>> listTemplatesWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = listTemplatesValidateBeforeCall(null);
@@ -3673,7 +3673,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call listTemplatesAsync(final ApiCallback<List<String>> _callback) throws ApiException {
 
@@ -3690,7 +3690,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call openApiCall(final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3752,7 +3752,7 @@ public class HyperfoilApi {
 	 * @return File
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public File openApi() throws ApiException {
 		ApiResponse<File> localVarResp = openApiWithHttpInfo();
@@ -3765,7 +3765,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;File&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<File> openApiWithHttpInfo() throws ApiException {
 		okhttp3.Call localVarCall = openApiValidateBeforeCall(null);
@@ -3781,7 +3781,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call openApiAsync(final ApiCallback<File> _callback) throws ApiException {
 
@@ -3799,7 +3799,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call shutdownCall(Boolean force, final ApiCallback _callback) throws ApiException {
 		String basePath = null;
@@ -3865,7 +3865,7 @@ public class HyperfoilApi {
 	 * @param force  (optional, default to false)
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public void shutdown(Boolean force) throws ApiException {
 		shutdownWithHttpInfo(force);
@@ -3878,7 +3878,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Void&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Void> shutdownWithHttpInfo(Boolean force) throws ApiException {
 		okhttp3.Call localVarCall = shutdownValidateBeforeCall(force, null);
@@ -3893,7 +3893,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call shutdownAsync(Boolean force, final ApiCallback<Void> _callback) throws ApiException {
 
@@ -3913,7 +3913,7 @@ public class HyperfoilApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call startBenchmarkCall(String name, String desc, String xTriggerJob, String runId,
 			List<String> templateParam, final ApiCallback _callback) throws ApiException {
@@ -4004,7 +4004,7 @@ public class HyperfoilApi {
 	 * @return Run
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public Run startBenchmark(String name, String desc, String xTriggerJob, String runId, List<String> templateParam)
 			throws ApiException {
@@ -4023,7 +4023,7 @@ public class HyperfoilApi {
 	 * @return ApiResponse&lt;Run&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 *
-
+	
 	 */
 	public ApiResponse<Run> startBenchmarkWithHttpInfo(String name, String desc, String xTriggerJob, String runId,
 			List<String> templateParam) throws ApiException {
@@ -4045,7 +4045,7 @@ public class HyperfoilApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 *
-
+	
 	 */
 	public okhttp3.Call startBenchmarkAsync(String name, String desc, String xTriggerJob, String runId,
 			List<String> templateParam, final ApiCallback<Run> _callback) throws ApiException {

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollector.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollector.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import java.util.ArrayList;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilder.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import java.util.List;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsRelatedWaiterException.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsRelatedWaiterException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import java.util.List;

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsReport.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsReport.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import java.util.List;

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/helm/wildfly/EapHelmChartReleaseAdapterTest.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/helm/wildfly/EapHelmChartReleaseAdapterTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.helm.wildfly;
 
 import java.util.List;

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilderTest.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorBuilderTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import java.net.MalformedURLException;

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorTest.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/util/k8s/log/collect/PodLogsCollectorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.provision.util.k8s.log.collect;
 
 import static org.mockito.Mockito.mock;

--- a/testsuite/deployments/deployments-provider/pom.xml
+++ b/testsuite/deployments/deployments-provider/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <project.version>${project.version}</project.version>
-        <formatting-style-base-directory>${project.parent.parent.parent.basedir}/ide-config/</formatting-style-base-directory>
 
         <!-- By default, the following prop is empty, stating that the build profile for WildFly deployments is the community one -->
         <intersmash.deployments.wildfly.build.profile />

--- a/testsuite/deployments/deployments-provider/src/test/java/org/jboss/intersmash/test/deployments/WildflyDeploymentApplicationConfigurationTest.java
+++ b/testsuite/deployments/deployments-provider/src/test/java/org/jboss/intersmash/test/deployments/WildflyDeploymentApplicationConfigurationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.test.deployments;
 
 import org.junit.jupiter.api.Assertions;

--- a/testsuite/deployments/eap7-shared/eap7-bootable-jar/pom.xml
+++ b/testsuite/deployments/eap7-shared/eap7-bootable-jar/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <formatting-style-base-directory>${project.parent.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
     </properties>
 
     <dependencyManagement>

--- a/testsuite/deployments/eap7-shared/eap7-helloworld/pom.xml
+++ b/testsuite/deployments/eap7-shared/eap7-helloworld/pom.xml
@@ -13,10 +13,6 @@
 
     <name>Intersmash Test Deployments (EAP 7): Hello World example</name>
 
-    <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in WildFly -->
         <dependency>

--- a/testsuite/deployments/eap7-shared/eap7-helloworld/src/main/java/org/jboss/as/quickstarts/helloworld/HelloService.java
+++ b/testsuite/deployments/eap7-shared/eap7-helloworld/src/main/java/org/jboss/as/quickstarts/helloworld/HelloService.java
@@ -1,13 +1,12 @@
-/*
- * JBoss, Home of Professional Open Source
- * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/testsuite/deployments/eap7-shared/eap7-helloworld/src/main/java/org/jboss/as/quickstarts/helloworld/HelloWorldServlet.java
+++ b/testsuite/deployments/eap7-shared/eap7-helloworld/src/main/java/org/jboss/as/quickstarts/helloworld/HelloWorldServlet.java
@@ -1,13 +1,12 @@
-/*
- * JBoss, Home of Professional Open Source
- * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/testsuite/deployments/openshift-jakarta-sample-standalone/pom.xml
+++ b/testsuite/deployments/openshift-jakarta-sample-standalone/pom.xml
@@ -9,15 +9,9 @@
     <name>Intersmash Test Deployments: OpenShift Jakarta Sample standalone deployment</name>
 
     <properties>
-        <formatting-style-base-directory>${project.basedir}/ide-config</formatting-style-base-directory>
-        <formatting-style-file>eclipse-format.xml</formatting-style-file>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
-        <version.impsort-maven-plugin>1.8.0</version.impsort-maven-plugin>
-        <version.ide-config>1.1</version.ide-config>
-        <version.formatter-maven-plugin>2.21.0</version.formatter-maven-plugin>
 
         <version.wildfly-server>35.0.0.Final</version.wildfly-server>
         <!-- WildFly Maven Plugin coordinates -->
@@ -107,16 +101,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>net.revelc.code.formatter</groupId>
-                    <artifactId>formatter-maven-plugin</artifactId>
-                    <version>${version.formatter-maven-plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>net.revelc.code</groupId>
-                    <artifactId>impsort-maven-plugin</artifactId>
-                    <version>${version.impsort-maven-plugin}</version>
-                </plugin>
 
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
@@ -127,40 +111,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <configuration>
-                    <configFile>${formatting-style-base-directory}/${formatting-style-file}</configFile>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>format</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>net.revelc.code</groupId>
-                <artifactId>impsort-maven-plugin</artifactId>
-                <configuration>
-                    <groups>jakarta.,java.,javax.,org.,com.</groups>
-                    <staticGroups>*</staticGroups>
-                    <removeUnused>true</removeUnused>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sort-imports</id>
-                        <goals>
-                            <goal>sort</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/testsuite/deployments/openshift-jakarta-sample-standalone/pom.xml
+++ b/testsuite/deployments/openshift-jakarta-sample-standalone/pom.xml
@@ -145,6 +145,9 @@
                 <configuration>
                     <!-- define a language-specific format -->
                     <java>
+                        <removeUnusedImports/>
+                        <importOrder/>
+                        <eclipse/>
                         <!-- make sure every file has the following copyright header.
                           optionally, Spotless can set copyright years by digging
                           through git history (see "license" section below) -->

--- a/testsuite/deployments/openshift-jakarta-sample-standalone/src/main/java/org/wildfly/sample/HelloWorldApplication.java
+++ b/testsuite/deployments/openshift-jakarta-sample-standalone/src/main/java/org/wildfly/sample/HelloWorldApplication.java
@@ -3,7 +3,6 @@ package org.wildfly.sample;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
-
 import java.util.HashSet;
 import java.util.Set;
 

--- a/testsuite/deployments/pom.xml
+++ b/testsuite/deployments/pom.xml
@@ -20,8 +20,6 @@
     </modules>
 
     <properties>
-        <formatting-style-base-directory>${project.parent.basedir}/ide-config</formatting-style-base-directory>
-
         <version.maven-install-plugin>3.0.0-M1</version.maven-install-plugin>
         <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
     </properties>

--- a/testsuite/deployments/wildfly-shared/wildfly-bootable-jar/pom.xml
+++ b/testsuite/deployments/wildfly-shared/wildfly-bootable-jar/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <formatting-style-base-directory>${project.parent.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
     </properties>
 
     <dependencyManagement>

--- a/testsuite/deployments/wildfly-shared/wildfly-helloworld/pom.xml
+++ b/testsuite/deployments/wildfly-shared/wildfly-helloworld/pom.xml
@@ -13,10 +13,6 @@
 
     <name>Intersmash Test Deployments (Wildfly): Hello World example</name>
 
-    <properties>
-        <formatting-style-base-directory>${project.parent.parent.parent.parent.basedir}/ide-config</formatting-style-base-directory>
-    </properties>
-
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in WildFly -->
         <dependency>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -12,7 +12,6 @@
     <name>Intersmash Testsuite: Integration tests</name>
 
     <properties>
-        <formatting-style-base-directory>${project.parent.parent.basedir}/ide-config</formatting-style-base-directory>
         <!--
             By default, the following prop is set to community, stating that the test execution profile is using
             community images and deliverables

--- a/testsuite/integration-tests/src/main/java/org/jboss/intersmash/testsuite/junit5/categories/KubernetesTest.java
+++ b/testsuite/integration-tests/src/main/java/org/jboss/intersmash/testsuite/junit5/categories/KubernetesTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.junit5.categories;
 
 import java.lang.annotation.Retention;

--- a/testsuite/integration-tests/src/main/java/org/jboss/intersmash/testsuite/junit5/categories/OpenShiftTest.java
+++ b/testsuite/integration-tests/src/main/java/org/jboss/intersmash/testsuite/junit5/categories/OpenShiftTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.junit5.categories;
 
 import java.lang.annotation.Retention;

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/k8s/NamespaceCreationCapable.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/k8s/NamespaceCreationCapable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.k8s;
 
 import org.jboss.intersmash.k8s.junit5.KubernetesNamespaceCreator;

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/k8s/client/binary/KubernetesClientBinaryTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/k8s/client/binary/KubernetesClientBinaryTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.k8s.client.binary;
 
 import org.jboss.intersmash.k8s.client.Kuberneteses;

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/openshift/ProjectCreationCapable.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/openshift/ProjectCreationCapable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.openshift;
 
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenDataHubOpenShiftOperatorProvisionerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/OpenDataHubOpenShiftOperatorProvisionerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.provision.openshift;
 
 import java.io.IOException;

--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/RhSsoTemplateTestCase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/RhSsoTemplateTestCase.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.intersmash.testsuite.provision.openshift;
 
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
## Description
Removing revelc imsort and formatting, removing the ide-config dir and use the Spotless Maven plugin to fix headers and manage  impsort/formatting

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift
