### PR TITLE
[issue-285] - Add a utility class and Javadoc to the style-config sub-module

### DIFF
--- a/style-config/pom.xml
+++ b/style-config/pom.xml
@@ -12,14 +12,19 @@
 
     <name>Intersmash code style configuration assets</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <!--
                 The style-config artifact must be published because it is used by other Intersmash projects

--- a/style-config/src/main/java/org/jboss/intersmash/configs/StyleConfigInformation.java
+++ b/style-config/src/main/java/org/jboss/intersmash/configs/StyleConfigInformation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.intersmash.configs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Provides methods to access checkstyle configuration.
+ */
+public class StyleConfigInformation {
+
+	/**
+	 * Get the contents of the {@code eclipse-formatter.xml} file
+	 * @return a string representing the contents of the {@code eclipse-formatter.xml} file
+	 * @throws IOException If the {@code eclipse-formatter.xml} resource is not available
+	 */
+	public String getEclipseFormatterContents() throws IOException {
+		InputStream resourceAsStream = StyleConfigInformation.class.getClassLoader().getResourceAsStream(
+				"org/jboss/intersmash/configs/eclipse-formatter.xml");
+		if (resourceAsStream == null) {
+			throw new IllegalStateException("\"eclipse-formatter.xml\" contents not found.");
+		}
+		try (BufferedReader bufferedReadr = new BufferedReader(
+				new InputStreamReader(resourceAsStream, StandardCharsets.UTF_8))) {
+			return bufferedReadr.lines().toString();
+		}
+	}
+}

--- a/style-config/src/test/java/org/jboss/intersmash/configs/StyleConfigInformationTest.java
+++ b/style-config/src/test/java/org/jboss/intersmash/configs/StyleConfigInformationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.intersmash.configs;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StyleConfigInformationTest {
+	@Test
+	void testEclipseFormatterContentsIsNotEmpty() throws IOException {
+		StyleConfigInformation styleConfigInformation = new StyleConfigInformation();
+		final String actualContentsString = styleConfigInformation.getEclipseFormatterContents();
+		Assertions.assertNotNull(actualContentsString, "\"eclipse-formatter.xml\" contents are null");
+		Assertions.assertNotEquals("", actualContentsString.trim(),
+				"\"eclipse-formatter.xml\" contents are empty");
+	}
+}


### PR DESCRIPTION
## Description
Adding a utility class  and a test to the `style-config` submodule, so that Javadoc can be generated.

Resolves #285 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - **N/A** I tested my code in OpenShift - _non-functional changes do not require OpenSHift CI checks_
