### PR TITLE
[issue-295] - Add support for configuring installed Operator version

### DIFF
--- a/core/src/main/java/org/jboss/intersmash/IntersmashConfig.java
+++ b/core/src/main/java/org/jboss/intersmash/IntersmashConfig.java
@@ -44,6 +44,7 @@ public class IntersmashConfig {
 	private static final String INFINISPAN_OPERATOR_INDEX_IMAGE = "intersmash.infinispan.operators.index_image";
 	private static final String INFINISPAN_OPERATOR_CHANNEL = "intersmash.infinispan.operators.channel";
 	private static final String INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "intersmash.infinispan.operators.package_manifest";
+	private static final String INFINISPAN_OPERATOR_VERSION = "intersmash.infinispan.operators.version";
 	private static final String COMMUNITY_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "infinispan";
 	private static final String PRODUCT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = "datagrid";
 	private static final String DEFAULT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_INFINISPAN_OPERATOR_PACKAGE_MANIFEST;
@@ -54,7 +55,9 @@ public class IntersmashConfig {
 	private static final String RHSSO_OPERATOR_CHANNEL = "intersmash.rhsso.operators.channel";
 	private static final String KEYCLOAK_OPERATOR_CHANNEL = "intersmash.keycloak.operators.channel";
 	private static final String RHSSO_OPERATOR_PACKAGE_MANIFEST = "intersmash.rhsso.operators.package_manifest";
+	private static final String RHSSO_OPERATOR_VERSION = "intersmash.rhsso.operators.version";
 	private static final String KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "intersmash.keycloak.operators.package_manifest";
+	private static final String KEYCLOAK_OPERATOR_VERSION = "intersmash.keycloak.operators.version";
 	private static final String COMMUNITY_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "keycloak-operator";
 	private static final String PRODUCT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = "rhsso-operator";
 	private static final String DEFAULT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST;
@@ -62,6 +65,7 @@ public class IntersmashConfig {
 	private static final String WILDFLY_OPERATOR_INDEX_IMAGE = "intersmash.wildfly.operators.index_image";
 	private static final String WILDFLY_OPERATOR_CHANNEL = "intersmash.wildfly.operators.channel";
 	private static final String WILDFLY_OPERATOR_PACKAGE_MANIFEST = "intersmash.wildfly.operators.package_manifest";
+	private static final String WILDFLY_OPERATOR_VERSION = "intersmash.wildfly.operators.version";
 	private static final String COMMUNITY_WILDFLY_OPERATOR_PACKAGE_MANIFEST = "wildfly";
 	private static final String PRODUCT_WILDFLY_OPERATOR_PACKAGE_MANIFEST = "eap";
 	private static final String DEFAULT_WILDFLY_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_WILDFLY_OPERATOR_PACKAGE_MANIFEST;
@@ -69,6 +73,7 @@ public class IntersmashConfig {
 	private static final String KAFKA_OPERATOR_INDEX_IMAGE = "intersmash.kafka.operators.index_image";
 	private static final String KAFKA_OPERATOR_CHANNEL = "intersmash.kafka.operators.channel";
 	private static final String KAFKA_OPERATOR_PACKAGE_MANIFEST = "intersmash.kafka.operators.package_manifest";
+	private static final String KAFKA_OPERATOR_VERSION = "intersmash.kafka.operators.version";
 	private static final String COMMUNITY_KAFKA_OPERATOR_PACKAGE_MANIFEST = "strimzi-kafka-operator";
 	private static final String PRODUCT_KAFKA_OPERATOR_PACKAGE_MANIFEST = "amq-streams";
 	private static final String DEFAULT_KAFKA_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_KAFKA_OPERATOR_PACKAGE_MANIFEST;
@@ -76,6 +81,7 @@ public class IntersmashConfig {
 	private static final String ACTIVEMQ_OPERATOR_INDEX_IMAGE = "intersmash.activemq.operators.index_image";
 	private static final String ACTIVEMQ_OPERATOR_CHANNEL = "intersmash.activemq.operators.channel";
 	private static final String ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "intersmash.activemq.operators.package_manifest";
+	private static final String ACTIVEMQ_OPERATOR_VERSION = "intersmash.activemq.operators.version";
 	private static final String COMMUNITY_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "artemis";
 	private static final String PRODUCT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = "amq-broker-rhel8";
 	private static final String DEFAULT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST;
@@ -83,12 +89,14 @@ public class IntersmashConfig {
 	private static final String HYPERFOIL_OPERATOR_INDEX_IMAGE = "intersmash.hyperfoil.operators.index_image";
 	private static final String HYPERFOIL_OPERATOR_CHANNEL = "intersmash.hyperfoil.operators.channel";
 	private static final String HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = "intersmash.hyperfoil.operators.package_manifest";
+	private static final String HYPERFOIL_OPERATOR_VERSION = "intersmash.hyperfoil.operators.version";
 	private static final String COMMUNITY_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = "hyperfoil-bundle";
 	private static final String DEFAULT_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST;
 	private static final String OPEN_DATA_HUB_OPERATOR_CATALOG_SOURCE_NAME = "intersmash.odh.operators.catalog_source";
 	private static final String OPEN_DATA_HUB_OPERATOR_INDEX_IMAGE = "intersmash.odh.operators.index_image";
 	private static final String OPEN_DATA_HUB_OPERATOR_CHANNEL = "intersmash.odh.operators.channel";
 	private static final String OPEN_DATA_HUB_OPERATOR_PACKAGE_MANIFEST = "intersmash.odh.operators.package_manifest";
+	private static final String OPEN_DATA_HUB_OPERATOR_VERSION = "intersmash.odh.operators.version";
 	private static final String COMMUNITY_OPEN_DATA_HUB_OPERATOR_PACKAGE_MANIFEST = "opendatahub-operator";
 	private static final String DEFAULT_OPEN_DATA_HUB_OPERATOR_PACKAGE_MANIFEST = COMMUNITY_OPEN_DATA_HUB_OPERATOR_PACKAGE_MANIFEST;
 
@@ -96,6 +104,7 @@ public class IntersmashConfig {
 	private static final String OPENSHIFT_AI_OPERATOR_INDEX_IMAGE = "intersmash.rhods.operators.index_image";
 	private static final String OPENSHIFT_AI_OPERATOR_CHANNEL = "intersmash.rhods.operators.channel";
 	private static final String OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST = "intersmash.rhods.operators.package_manifest";
+	private static final String OPENSHIFT_AI_OPERATOR_VERSION = "intersmash.rhods.operators.version";
 	private static final String PRODUCT_OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST = "rhods-operator";
 	private static final String DEFAULT_OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST = PRODUCT_OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST;
 
@@ -167,6 +176,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(INFINISPAN_OPERATOR_PACKAGE_MANIFEST, DEFAULT_INFINISPAN_OPERATOR_PACKAGE_MANIFEST);
 	}
 
+	public static String infinispanOperatorVersion() {
+		return XTFConfig.get(INFINISPAN_OPERATOR_VERSION);
+	}
+
 	public static String rhSsoOperatorCatalogSource() {
 		return XTFConfig.get(RHSSO_OPERATOR_CATALOG_SOURCE_NAME, defaultOperatorCatalogSourceName());
 	}
@@ -181,6 +194,10 @@ public class IntersmashConfig {
 
 	public static String rhSsoOperatorPackageManifest() {
 		return XTFConfig.get(RHSSO_OPERATOR_PACKAGE_MANIFEST, PRODUCT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST);
+	}
+
+	public static String rhSsoOperatorVersion() {
+		return XTFConfig.get(RHSSO_OPERATOR_VERSION);
 	}
 
 	public static String wildflyOperatorCatalogSource() {
@@ -199,6 +216,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(WILDFLY_OPERATOR_PACKAGE_MANIFEST, DEFAULT_WILDFLY_OPERATOR_PACKAGE_MANIFEST);
 	}
 
+	public static String wildflyOperatorVersion() {
+		return XTFConfig.get(WILDFLY_OPERATOR_VERSION);
+	}
+
 	public static String kafkaOperatorCatalogSource() {
 		return XTFConfig.get(KAFKA_OPERATOR_CATALOG_SOURCE_NAME, defaultOperatorCatalogSourceName());
 	}
@@ -213,6 +234,10 @@ public class IntersmashConfig {
 
 	public static String kafkaOperatorPackageManifest() {
 		return XTFConfig.get(KAFKA_OPERATOR_PACKAGE_MANIFEST, DEFAULT_KAFKA_OPERATOR_PACKAGE_MANIFEST);
+	}
+
+	public static String kafkaOperatorVersion() {
+		return XTFConfig.get(KAFKA_OPERATOR_VERSION);
 	}
 
 	public static String activeMQOperatorCatalogSource() {
@@ -231,6 +256,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST, DEFAULT_ACTIVEMQ_OPERATOR_PACKAGE_MANIFEST);
 	}
 
+	public static String activeMQOperatorVersion() {
+		return XTFConfig.get(ACTIVEMQ_OPERATOR_VERSION);
+	}
+
 	public static String hyperfoilOperatorCatalogSource() {
 		return XTFConfig.get(HYPERFOIL_OPERATOR_CATALOG_SOURCE_NAME, defaultOperatorCatalogSourceName());
 	}
@@ -245,6 +274,10 @@ public class IntersmashConfig {
 
 	public static String hyperfoilOperatorPackageManifest() {
 		return XTFConfig.get(HYPERFOIL_OPERATOR_PACKAGE_MANIFEST, DEFAULT_HYPERFOIL_OPERATOR_PACKAGE_MANIFEST);
+	}
+
+	public static String hyperfoilOperatorVersion() {
+		return XTFConfig.get(HYPERFOIL_OPERATOR_VERSION);
 	}
 
 	public static String bootableJarImageURL() {
@@ -422,6 +455,10 @@ public class IntersmashConfig {
 		return XTFConfig.get(KEYCLOAK_OPERATOR_PACKAGE_MANIFEST, DEFAULT_KEYCLOAK_OPERATOR_PACKAGE_MANIFEST);
 	}
 
+	public static String keycloakOperatorVersion() {
+		return XTFConfig.get(KEYCLOAK_OPERATOR_VERSION);
+	}
+
 	/**
 	 * Read the configuration property for the Open Data Hub Operator catalog source, i.e. {@code intersmash.odh.operators.catalog_source}.
 	 *
@@ -462,6 +499,16 @@ public class IntersmashConfig {
 	}
 
 	/**
+	 * Read the configuration property for the Open Data Hub Operator version to be used, i.e. {@code intersmash.odh.operators.version}.
+	 *
+	 * @return The value for the {@code intersmash.odh.operators.version} property
+	 * that should be used for this operator, i.e. {@code opendatahub-operator} property.
+	 */
+	public static String openDataHubOperatorVersion() {
+		return XTFConfig.get(OPEN_DATA_HUB_OPERATOR_VERSION);
+	}
+
+	/**
 	 * Read the configuration property for the OpenShift AI Operator catalog source, i.e. {@code intersmash.rhods.operators.catalog_source}.
 	 *
 	 * @return The value for the {@code intersmash.rhods.operators.catalog_source} property or the default catalog source,
@@ -498,5 +545,9 @@ public class IntersmashConfig {
 	 */
 	public static String openShiftAIOperatorPackageManifest() {
 		return XTFConfig.get(OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST, DEFAULT_OPENSHIFT_AI_OPERATOR_PACKAGE_MANIFEST);
+	}
+
+	public static String openShiftAIOperatorVersion() {
+		return XTFConfig.get(OPENSHIFT_AI_OPERATOR_VERSION);
 	}
 }

--- a/core/src/main/java/org/jboss/intersmash/provision/olm/Subscription.java
+++ b/core/src/main/java/org/jboss/intersmash/provision/olm/Subscription.java
@@ -43,8 +43,8 @@ public class Subscription extends io.fabric8.openshift.api.model.operatorhub.v1a
 
 	private SubscriptionFluent<SubscriptionBuilder>.SpecNested<SubscriptionBuilder> getConfiguredSubscriptionBuilder(
 			final String sourceNamespace, final String targetNamespace, final String source, final String name,
-			final String channel, final String installPlanApproval) {
-		return new SubscriptionBuilder()
+			final String channel, final String installPlanApproval, final String startingCSV) {
+		SubscriptionFluent<SubscriptionBuilder>.SpecNested<SubscriptionBuilder> subscriptionBuilderSpecNested = new SubscriptionBuilder()
 				.withNewMetadata()
 				.withName(name)
 				.withNamespace(targetNamespace)
@@ -55,14 +55,18 @@ public class Subscription extends io.fabric8.openshift.api.model.operatorhub.v1a
 				.withSource(source)
 				.withSourceNamespace(sourceNamespace)
 				.withInstallPlanApproval(Strings.isNullOrEmpty(installPlanApproval) ? "Automatic" : installPlanApproval);
+		if (startingCSV != null && !startingCSV.isBlank()) {
+			subscriptionBuilderSpecNested.withStartingCSV(startingCSV);
+		}
+		return subscriptionBuilderSpecNested;
 	}
 
 	public Subscription(final String sourceNamespace, final String targetNamespace, final String source,
-			final String name, final String channel, final String installPlanApproval,
+			final String name, final String channel, final String installPlanApproval, final String startingCSV,
 			final Map<String, String> envVariables) {
 		this();
 		io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription loaded = getConfiguredSubscriptionBuilder(
-				sourceNamespace, targetNamespace, source, name, channel, installPlanApproval)
+				sourceNamespace, targetNamespace, source, name, channel, installPlanApproval, startingCSV)
 				.withNewConfig()
 				.addAllToEnv(
 						envVariables.entrySet().stream()
@@ -76,10 +80,10 @@ public class Subscription extends io.fabric8.openshift.api.model.operatorhub.v1a
 	}
 
 	public Subscription(final String sourceNamespace, final String targetNamespace, final String source,
-			final String name, final String channel, final String installPlanApproval) {
+			final String name, final String channel, final String installPlanApproval, final String startingCSV) {
 		this();
 		io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription loaded = getConfiguredSubscriptionBuilder(
-				sourceNamespace, targetNamespace, source, name, channel, installPlanApproval)
+				sourceNamespace, targetNamespace, source, name, channel, installPlanApproval, startingCSV)
 				.endSpec()
 				.build();
 		this.setMetadata(loaded.getMetadata());

--- a/core/src/test/java/org/jboss/intersmash/provision/olm/SubscriptionTest.java
+++ b/core/src/test/java/org/jboss/intersmash/provision/olm/SubscriptionTest.java
@@ -40,6 +40,7 @@ public class SubscriptionTest {
 				"dummy-operator",
 				"alpha",
 				OperatorProvisioner.INSTALLPLAN_APPROVAL_MANUAL,
+				"my-operator-current-CSV",
 				Map.of(
 						"PROP_1", propertyValue,
 						"PROP_2", propertyValue,

--- a/docs/XTF-Configuration-Properties.md
+++ b/docs/XTF-Configuration-Properties.md
@@ -20,10 +20,11 @@
 | intersmash.wildfly.helm.charts.branch              | Wildfly/JBoss EAP 8 Helm Charts repository branch                                                                                |	
 | intersmash.wildfly.helm.charts.name                | Wildfly/JBoss EAP 8 Helm Charts repository namespaces                                                                            |
 |                                                    |                                                                                                                                  |
-| intersmash.wildfly.operators.catalog_source        | Wildfly/JBoss EAP custom catalog for Operator                                                                                    |
-| intersmash.wildfly.operators.index_image           | Wildfly/JBoss EAP custom index image for Operator                                                                                |
-| intersmash.wildfly.operators.package_manifest      | Wildfly/JBoss EAP custom package manifest for Operator                                                                           |
-| intersmash.wildfly.operators.channel               | Wildfly/JBoss EAP desired channel for Operator                                                                                   |
+| intersmash.wildfly.operators.catalog_source        | Wildfly/JBoss EAP catalog for Operator                                                                                           |
+| intersmash.wildfly.operators.index_image           | Wildfly/JBoss EAP index image for Operator                                                                                       |
+| intersmash.wildfly.operators.package_manifest      | Wildfly/JBoss EAP package manifest for Operator                                                                                  |
+| intersmash.wildfly.operators.channel               | Wildfly/JBoss EAP channel for Operator                                                                                           |
+| intersmash.wildfly.operators.version               | Wildfly/JBoss EAP version for Operator                                                                                           |                                                                                   |
 |                                                    |                                                                                                                                  |
 | intersmash.bootable.jar.image                      | Open JDK image URL that can be used as the base for an OpenShift Wildfly/JBoss EAP Bootable JAR                                  |
 | intersmash.eap7.image                              | JBoss EAP 7 Builder image URL                                                                                                    |
@@ -32,39 +33,45 @@
 | intersmash.eap7.templates.path                     | JBoss EAP 7 openShift Templates base path                                                                                        |
 |                                                    |                                                                                                                                  |
 | intersmash.infinispan.image                        | Infinispan/Red Hat DataGrid image URL                                                                                            |
-| intersmash.infinispan.operators.catalog_source     | Infinispan/Red Hat DataGrid custom catalog for Operator                                                                          |
-| intersmash.infinispan.operators.index_image        | Infinispan/Red Hat DataGrid custom index image for Operator                                                                      |
-| intersmash.infinispan.operators.package_manifest   | Infinispan/Red Hat DataGrid custom package manifest for Operator                                                                 |
-| intersmash.infinispan.operators.channel            | Infinispan/Red Hat DataGrid desired channel for Operator                                                                         |
+| intersmash.infinispan.operators.catalog_source     | Infinispan/Red Hat DataGrid catalog for Operator                                                                                 |
+| intersmash.infinispan.operators.index_image        | Infinispan/Red Hat DataGrid index image for Operator                                                                             |
+| intersmash.infinispan.operators.package_manifest   | Infinispan/Red Hat DataGrid package manifest for Operator                                                                        |
+| intersmash.infinispan.operators.channel            | Infinispan/Red Hat DataGrid channel for Operator                                                                                 |
+| intersmash.infinispan.operators.version            | Infinispan/Red Hat DataGrid version for Operator                                                                                 |
 |                                                    |                                                                                                                                  |
-| intersmash.keycloak.image                          | Keycloak image URL                                                                                                               |
-| intersmash.keycloak.operators.catalog_source       | Keycloak custom catalog for Operator                                                                                             |
-| intersmash.keycloak.operators.index_image          | Keycloak custom index image for Operator                                                                                         |
-| intersmash.keycloak.operators.package_manifest     | Keycloak custom package manifest for Operator                                                                                    |
-| intersmash.keycloak.operators.channel              | Keycloak desired channel for Operator                                                                                            |
+| intersmash.keycloak.image                          | Keycloak/Red Hat Build of Keycloak image URL                                                                                     |
+| intersmash.keycloak.operators.catalog_source       | Keycloak/Red Hat Build of Keycloak catalog for Operator                                                                          |
+| intersmash.keycloak.operators.index_image          | Keycloak/Red Hat Build of Keycloak index image for Operator                                                                      |
+| intersmash.keycloak.operators.package_manifest     | Keycloak/Red Hat Build of Keycloak package manifest for Operator                                                                 |
+| intersmash.keycloak.operators.channel              | Keycloak/Red Hat Build of Keycloak channel for Operator                                                                          |
+| intersmash.keycloak.operators.channel              | Keycloak/Red Hat Build of Keycloak version for Operator                                                                          |
 |                                                    |                                                                                                                                  |
 | intersmash.rhsso.image                             | Red Hat Single Sign On 7 image URL                                                                                               |
-| intersmash.rhsso.operators.catalog_source          | Red Hat Single Sign On 7 custom catalog for Operator                                                                             |
-| intersmash.rhsso.operators.index_image             | Red Hat Single Sign On 7 custom index image for Operator                                                                         |
-| intersmash.rhsso.operators.package_manifest        | Red Hat Single Sign On 7 custom package manifest for Operator                                                                    |
-| intersmash.rhsso.operators.channel                 | Red Hat Single Sign On 7 desired channel for Operator                                                                            |
+| intersmash.rhsso.operators.catalog_source          | Red Hat Single Sign On 7 catalog for Operator                                                                                    |
+| intersmash.rhsso.operators.index_image             | Red Hat Single Sign On 7 index image for Operator                                                                                |
+| intersmash.rhsso.operators.package_manifest        | Red Hat Single Sign On 7 package manifest for Operator                                                                           |
+| intersmash.rhsso.operators.channel                 | Red Hat Single Sign On 7 channel for Operator                                                                                    |
+| intersmash.rhsso.operators.version                 | Red Hat Single Sign On 7 version for Operator                                                                                    |
 |                                                    |                                                                                                                                  |
-| intersmash.kafka.operators.catalog_source          | Kafka/Streams for Apache Kafka custom catalog for Operator                                                                            |
-| intersmash.kafka.operators.index_image             | Kafka/Streams for Apache Kafka custom index image for Operator                                                                        |
-| intersmash.kafka.operators.package_manifest        | Kafka/Streams for Apache Kafka custom package manifest for Operator                                                                   |
-| intersmash.kafka.operators.channel                 | Kafka/Streams for Apache Kafka desired channel for Operator                                                                           |
+| intersmash.kafka.operators.catalog_source          | Kafka/Streams for Apache Kafka catalog for Operator                                                                              |
+| intersmash.kafka.operators.index_image             | Kafka/Streams for Apache Kafka index image for Operator                                                                          |
+| intersmash.kafka.operators.package_manifest        | Kafka/Streams for Apache Kafka package manifest for Operator                                                                     |
+| intersmash.kafka.operators.channel                 | Kafka/Streams for Apache Kafka channel for Operator                                                                              |
+| intersmash.kafka.operators.version                 | Kafka/Streams for Apache Kafka version for Operator                                                                              |
 |                                                    |                                                                                                                                  |
 | intersmash.activemq.image                          | Apache ActiveMQ Broker/Red Hat AMQ Broker image URL                                                                              |
 | intersmash.activemq.init.image                     | ActiveMQ Broker/Red Hat AMQ Broker init image URL                                                                                |
-| intersmash.activemq.operators.catalog_source       | ActiveMQ Broker/Red Hat AMQ Broker custom catalog for Operator                                                                   |
-| intersmash.activemq.operators.index_image          | ActiveMQ Broker/Red Hat AMQ Broker custom index image for Operators                                                              |
-| intersmash.activemq.operators.package_manifest     | ActiveMQ Broker/Red Hat AMQ Broker custom package manifest for Operators                                                         |
-| intersmash.activemq.operators.channel              | ActiveMQ Broker/Red Hat AMQ Broker desired channel for Operator                                                                  |
+| intersmash.activemq.operators.catalog_source       | ActiveMQ Broker/Red Hat AMQ Broker catalog for Operator                                                                          |
+| intersmash.activemq.operators.index_image          | ActiveMQ Broker/Red Hat AMQ Broker index image for Operators                                                                     |
+| intersmash.activemq.operators.package_manifest     | ActiveMQ Broker/Red Hat AMQ Broker package manifest for Operators                                                                |
+| intersmash.activemq.operators.channel              | ActiveMQ Broker/Red Hat AMQ Broker channel for Operator                                                                          |
+| intersmash.activemq.operators.version              | ActiveMQ Broker/Red Hat AMQ Broker version for Operator                                                                          |
 |                                                    |                                                                                                                                  |
-| intersmash.hyperfoil.operators.catalog_source      | HyperFoil custom catalog for Operator                                                                                            |
-| intersmash.hyperfoil.operators.index_image         | HyperFoil custom index image for Operators                                                                                       |
-| intersmash.hyperfoil.operators.package_manifest    | HyperFoil custom package manifest for Operators                                                                                  |
-| intersmash.hyperfoil.operators.channel             | HyperFoil desired channel for Operator                                                                                           |
+| intersmash.hyperfoil.operators.catalog_source      | HyperFoil catalog for Operator                                                                                                   |
+| intersmash.hyperfoil.operators.index_image         | HyperFoil index image for Operators                                                                                              |
+| intersmash.hyperfoil.operators.package_manifest    | HyperFoil package manifest for Operators                                                                                         |
+| intersmash.hyperfoil.operators.channel             | HyperFoil channel for Operator                                                                                                   |
+| intersmash.hyperfoil.operators.version             | HyperFoil version for Operator                                                                                                   |
 |                                                    |                                                                                                                                  |
 | intersmash.mysql.image                             | MySql image URL                                                                                                                  |
 | intersmash.postgresql.image                        | PostgreSql image URL                                                                                                             |

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/ActiveMQOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/ActiveMQOperatorProvisioner.java
@@ -79,6 +79,11 @@ public abstract class ActiveMQOperatorProvisioner<C extends NamespacedKubernetes
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.activeMQOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = () -> false;
 		subscribe();

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/HyperfoilOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/HyperfoilOperatorProvisioner.java
@@ -114,6 +114,11 @@ public abstract class HyperfoilOperatorProvisioner<C extends NamespacedKubernete
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.hyperfoilOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = getFailFastCheck();
 

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/InfinispanOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/InfinispanOperatorProvisioner.java
@@ -119,6 +119,11 @@ public abstract class InfinispanOperatorProvisioner<C extends NamespacedKubernet
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.infinispanOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		subscribe();
 		// create Infinispan CR

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/KafkaOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/KafkaOperatorProvisioner.java
@@ -325,6 +325,11 @@ public abstract class KafkaOperatorProvisioner<C extends NamespacedKubernetesCli
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.kafkaOperatorVersion();
+	}
+
+	@Override
 	public List<Pod> getPods() {
 		return this.client().pods().inNamespace(this.client().getNamespace())
 				.withLabel("strimzi.io/cluster", getApplication().getName()).list().getItems();

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/KeycloakOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/KeycloakOperatorProvisioner.java
@@ -79,6 +79,11 @@ public abstract class KeycloakOperatorProvisioner<C extends NamespacedKubernetes
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.keycloakOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = () -> false;
 		// Keycloak Operator codebase contains the name of the Keycloak image to deploy: user can override Keycloak image to

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/OpenDataHubOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/OpenDataHubOperatorProvisioner.java
@@ -72,6 +72,11 @@ public abstract class OpenDataHubOperatorProvisioner<C extends NamespacedKuberne
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.openDataHubOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = getFailFastCheck();
 

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/OpenShiftAIOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/OpenShiftAIOperatorProvisioner.java
@@ -72,6 +72,11 @@ public abstract class OpenShiftAIOperatorProvisioner<C extends NamespacedKuberne
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.openShiftAIOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = getFailFastCheck();
 

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/RhSsoOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/RhSsoOperatorProvisioner.java
@@ -99,6 +99,11 @@ public abstract class RhSsoOperatorProvisioner<C extends NamespacedKubernetesCli
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.rhSsoOperatorVersion();
+	}
+
+	@Override
 	public void deploy() {
 		FailFastCheck ffCheck = () -> false;
 		// Keycloak Operator codebase contains the name of the Keycloak image to deploy: user can override Keycloak image to

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/operator/WildflyOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/operator/WildflyOperatorProvisioner.java
@@ -98,6 +98,11 @@ public abstract class WildflyOperatorProvisioner<C extends NamespacedKubernetesC
 	}
 
 	@Override
+	public String getVersion() {
+		return IntersmashConfig.wildflyOperatorVersion();
+	}
+
+	@Override
 	public URL getURL() {
 		String url = "http://" + wildFlyServer().get().getStatus().getHosts().get(0);
 		try {

--- a/provisioners/src/test/java/org/jboss/intersmash/provision/olm/SerializationCapableResourceTestCase.java
+++ b/provisioners/src/test/java/org/jboss/intersmash/provision/olm/SerializationCapableResourceTestCase.java
@@ -39,7 +39,8 @@ public class SerializationCapableResourceTestCase {
 						"redhat-operators",
 						"dummy-operator",
 						"alpha",
-						OperatorProvisioner.INSTALLPLAN_APPROVAL_MANUAL),
+						OperatorProvisioner.INSTALLPLAN_APPROVAL_MANUAL,
+						"my-operator-CSV"),
 				new CatalogSource(
 						"my-custom-cs",
 						"my-namespace",


### PR DESCRIPTION
## Description

Adding support for exteranlizing the configuration of an Operator version.

Resolves #295 

---
**OpenShift CI checks (internal reference)**:

- **job**: eap-8.x-intersmash-integration-tests-community, **number**: 140 :white_check_mark: 
  - one intermittent test failure is fixed in subsequent **eap-8.x-intersmash-integration-tests-community/141**
  
(tested via #299)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift
