### PR TITLE
[issue-297] - Fix InstallPlan retrieval and approval when installed in another namespace

### DIFF
--- a/core/src/main/java/org/jboss/intersmash/provision/k8s/KubernetesProvisioner.java
+++ b/core/src/main/java/org/jboss/intersmash/provision/k8s/KubernetesProvisioner.java
@@ -46,6 +46,10 @@ public interface KubernetesProvisioner<T extends Application> extends Provisione
 		return Kuberneteses.adminBinary().execute(args);
 	}
 
+	default String executeInNamespace(final String namespace, String... args) {
+		return Kuberneteses.adminBinary(namespace).execute(args);
+	}
+
 	@Override
 	default void preDeploy() {
 		// create secrets

--- a/core/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftProvisioner.java
+++ b/core/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftProvisioner.java
@@ -54,6 +54,10 @@ public interface OpenShiftProvisioner<T extends Application> extends Provisioner
 		return OpenShifts.adminBinary().execute(args);
 	}
 
+	default String executeInNamespace(final String namespace, String... args) {
+		return OpenShifts.adminBinary(namespace).execute(args);
+	}
+
 	@Override
 	default void preDeploy() {
 		// create secrets

--- a/core/src/main/java/org/jboss/intersmash/provision/operator/OperatorProvisioner.java
+++ b/core/src/main/java/org/jboss/intersmash/provision/operator/OperatorProvisioner.java
@@ -97,10 +97,13 @@ public abstract class OperatorProvisioner<A extends OperatorApplication, C exten
 
 	protected abstract String execute(String... args);
 
+	protected abstract String executeInNamespace(final String namespace, String... args);
+
 	public PackageManifest getPackageManifest(String operatorName, String operatorNamespace) {
 		try {
 			return new ObjectMapper()
-					.readValue(this.execute("get", "packagemanifest", operatorName, "-n", operatorNamespace, "-o", "json"),
+					.readValue(
+							this.executeInNamespace(operatorNamespace, "get", "packagemanifest", operatorName, "-o", "json"),
 							PackageManifest.class);
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("Couldn't deserialize package manifest data: " + operatorName, e);
@@ -109,7 +112,7 @@ public abstract class OperatorProvisioner<A extends OperatorApplication, C exten
 
 	public List<CatalogSource> getCatalogSources(final String catalogSourceNamespace) {
 		try {
-			return new ObjectMapper().readValue(this.execute("get", "catsrc", "-n", catalogSourceNamespace, "-o", "json"),
+			return new ObjectMapper().readValue(this.executeInNamespace(catalogSourceNamespace, "get", "catsrc", "-o", "json"),
 					CatalogSourceList.class).getItems();
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("Couldn't deserialize catalog source data: " + catalogSourceNamespace, e);
@@ -258,8 +261,8 @@ public abstract class OperatorProvisioner<A extends OperatorApplication, C exten
 				AtomicReference<String> catalogSourceStatus = new AtomicReference<>();
 				new SimpleWaiter(() -> {
 					// oc get CatalogSource redhat-operators -n openshift-marketplace -o template --template {{.status.connectionState.lastObservedState}}
-					catalogSourceStatus.set(this.execute("get", "CatalogSource", catalogSource.getMetadata().getName(),
-							"-n", operatorCatalogSourceNamespace,
+					catalogSourceStatus.set(this.executeInNamespace(operatorCatalogSourceNamespace,
+							"get", "CatalogSource", catalogSource.getMetadata().getName(),
 							"-o", "template", "--template",
 							"{{.status.connectionState.lastObservedState}}",
 							"--ignore-not-found"));
@@ -381,10 +384,12 @@ public abstract class OperatorProvisioner<A extends OperatorApplication, C exten
 			// wait for installPlan to be attached to the subscription
 			new SimpleWaiter(() -> {
 				// oc get subscription rhsso-operator -o template --template="{{.status.installplan.name}}"
-				installPlan.set(this.execute("get", "subscription", operatorSubscription.getMetadata().getName(),
-						"-o", "template", "--template",
-						"{{ if .status.installPlanRef.name }}{{.status.installPlanRef.name}}{{ end }}",
-						"--ignore-not-found"));
+				installPlan.set(
+						this.executeInNamespace(this.getTargetNamespace(),
+								"get", "subscription", operatorSubscription.getMetadata().getName(),
+								"-o", "template", "--template",
+								"{{ if .status.installPlanRef.name }}{{.status.installPlanRef.name}}{{ end }}",
+								"--ignore-not-found"));
 				if (!Strings.isNullOrEmpty(installPlan.get())) {
 					log.info("Pending approval on InstallPlan {} for Subscription {}", installPlan.get(),
 							operatorSubscription.getMetadata().getName());
@@ -395,7 +400,8 @@ public abstract class OperatorProvisioner<A extends OperatorApplication, C exten
 					.level(Level.DEBUG)
 					.failFast(getFailFastCheck())
 					.waitFor();
-			String outcome = this.execute("patch", "InstallPlan", installPlan.get(),
+			String outcome = this.executeInNamespace(this.getTargetNamespace(),
+					"patch", "InstallPlan", installPlan.get(),
 					"--type", "merge", "--patch", "{\"spec\":{\"approved\":true}}");
 			if (!Strings.isNullOrEmpty(outcome) && outcome.contains("patched")) {
 				log.info("Approved InstallPlan {} for subscription {}",

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/k8s/HyperfoilKubernetesOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/k8s/HyperfoilKubernetesOperatorProvisioner.java
@@ -66,6 +66,11 @@ public class HyperfoilKubernetesOperatorProvisioner
 		return KubernetesProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return KubernetesProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	/**
 	 * On Kubernetes, the HyperFoil operator will expose the controller service externally via a {@code NodePort} type {@link Service}
 	 * @return A {@link URL} instance that represents the HyperFoil controller service external URL

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/ActiveMQOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/ActiveMQOpenShiftOperatorProvisioner.java
@@ -56,6 +56,11 @@ public class ActiveMQOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Client related
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/HyperfoilOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/HyperfoilOpenShiftOperatorProvisioner.java
@@ -68,6 +68,11 @@ public class HyperfoilOpenShiftOperatorProvisioner
 	}
 
 	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
+	@Override
 	protected FailFastCheck getFailFastCheck() {
 		if (ffCheck == null) {
 			ffCheck = FailFastUtils.getFailFastCheck(EventHelper.timeOfLastEventBMOrTestNamespaceOrEpoch(),

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/InfinispanOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/InfinispanOpenShiftOperatorProvisioner.java
@@ -65,6 +65,11 @@ public class InfinispanOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Infinispan related
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/KafkaOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/KafkaOpenShiftOperatorProvisioner.java
@@ -53,6 +53,11 @@ public class KafkaOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Client related
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/KeycloakOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/KeycloakOpenShiftOperatorProvisioner.java
@@ -62,6 +62,11 @@ public class KeycloakOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Operator based provisioning concrete implementation, see OperatorProvisioner
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenDataHubOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenDataHubOpenShiftOperatorProvisioner.java
@@ -69,17 +69,22 @@ public class OpenDataHubOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Related to generic provisioning behavior
 	// =================================================================================================================
 	@Override
 	protected void removeClusterServiceVersion() {
-		this.execute("delete", "csvs", currentCSV, "-n", this.getTargetNamespace(), "--ignore-not-found");
+		this.executeInNamespace(this.getTargetNamespace(), "delete", "csvs", currentCSV, "--ignore-not-found");
 	}
 
 	@Override
 	protected void removeSubscription() {
-		this.execute("delete", "subscription", packageManifestName, "-n", this.getTargetNamespace(), "--ignore-not-found");
+		this.executeInNamespace(this.getTargetNamespace(), "delete", "subscription", packageManifestName, "--ignore-not-found");
 	}
 
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftAIOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftAIOpenShiftOperatorProvisioner.java
@@ -69,17 +69,22 @@ public class OpenShiftAIOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Related to generic provisioning behavior
 	// =================================================================================================================
 	@Override
 	protected void removeClusterServiceVersion() {
-		this.execute("delete", "csvs", currentCSV, "-n", this.getTargetNamespace(), "--ignore-not-found");
+		this.executeInNamespace(this.getTargetNamespace(), "delete", "csvs", currentCSV, "--ignore-not-found");
 	}
 
 	@Override
 	protected void removeSubscription() {
-		this.execute("delete", "subscription", packageManifestName, "-n", this.getTargetNamespace(), "--ignore-not-found");
+		this.execute(this.getTargetNamespace(), "delete", "subscription", packageManifestName, "--ignore-not-found");
 	}
 
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/RhSsoOpenShiftOperatorProvisioner.java
@@ -67,6 +67,11 @@ public class RhSsoOpenShiftOperatorProvisioner
 		return OpenShiftProvisioner.super.execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Operator based provisioning concrete implementation, see OperatorProvisioner
 	// =================================================================================================================

--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/WildflyOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/WildflyOpenShiftOperatorProvisioner.java
@@ -51,6 +51,11 @@ public class WildflyOpenShiftOperatorProvisioner
 		return OpenShifts.adminBinary().execute(args);
 	}
 
+	@Override
+	public String executeInNamespace(String namespace, String... args) {
+		return OpenShiftProvisioner.super.executeInNamespace(namespace, args);
+	}
+
 	// =================================================================================================================
 	// Client related
 	// =================================================================================================================


### PR DESCRIPTION
## Description
Improve *OperatorProvisioner(s) in order to be able to execute binary commands to a given namespace.

Fixes #297 

---
**OpenShift CI checks (internal reference)**:

- **job**: eap-8.x-intersmash-integration-tests-community, **number**: 140 :white_check_mark: 
  - one intermittent test failure is fixed in subsequent **eap-8.x-intersmash-integration-tests-community/141**
  
(tested via #299)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift
