### PR TITLE
[issue-300] - Fix KafkaOpenShiftOperatorProvisionerTest to make it run with community deliverables

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/kafka/KafkaOpenShiftOperatorProvisionerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/intersmash/testsuite/provision/openshift/kafka/KafkaOpenShiftOperatorProvisionerTest.java
@@ -23,6 +23,7 @@ import org.jboss.intersmash.junit5.IntersmashExtension;
 import org.jboss.intersmash.provision.olm.OperatorGroup;
 import org.jboss.intersmash.provision.openshift.KafkaOpenShiftOperatorProvisioner;
 import org.jboss.intersmash.provision.operator.KafkaOperatorProvisioner;
+import org.jboss.intersmash.testsuite.IntersmashTestsuiteProperties;
 import org.jboss.intersmash.testsuite.junit5.categories.OpenShiftTest;
 import org.jboss.intersmash.testsuite.openshift.ProjectCreationCapable;
 import org.junit.jupiter.api.Assertions;
@@ -63,7 +64,9 @@ public class KafkaOpenShiftOperatorProvisionerTest implements ProjectCreationCap
 	private static Stream<Arguments> applicationProvider() {
 		return Stream.of(
 				Arguments.of(new KafkaKRaftEphemeralOpenShiftOperatorApplication(), "stable"),
-				Arguments.of(new KafkaZookeperEphemeralOpenShiftOperatorApplication(), "amq-streams-2.9.x"));
+				Arguments.of(new KafkaZookeperEphemeralOpenShiftOperatorApplication(),
+						IntersmashTestsuiteProperties.isCommunityTestExecutionProfileEnabled() ? "strimzi-0.45.x"
+								: "amq-streams-2.9.x"));
 	}
 
 	private KafkaOpenShiftOperatorProvisioner initializeOperatorProvisioner(


### PR DESCRIPTION
## Description
Let KafkaOpenShiftOperatorProvisionerTest take the community deliverables case into account and set a correct channel name. 

Fixes #300 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [ ] I tested my code in OpenShift