### PR TITLE
[issue-306] - Fix default values for JBoss EAP 8.0 images in properties files

### DIFF
--- a/testsuite/integration-tests/eap80-global-test.properties
+++ b/testsuite/integration-tests/eap80-global-test.properties
@@ -13,8 +13,8 @@ xtf.junit.prebuilder.synchronized=true
 intersmash.mysql.image=registry.redhat.io/rhel10/mysql-84:latest
 intersmash.postgresql.image=registry.redhat.io/rhel8/postgresql-16:latest
 
-intersmash.wildfly.image=registry.redhat.io/jboss-eap-8/eap8-openjdk17-builder-openshift-rhel8:latest
-intersmash.wildfly.runtime.image=registry.redhat.io/jboss-eap-8/eap8-openjdk17-runtime-openshift-rhel8:latest
+intersmash.wildfly.image=registry.redhat.io/jboss-eap-8/eap8-openjdk21-builder-openshift-rhel9:latest
+intersmash.wildfly.runtime.image=registry.redhat.io/jboss-eap-8/eap8-openjdk21-runtime-openshift-rhel9:latest
 intersmash.wildfly.operators.catalog_source=redhat-operators
 intersmash.wildfly.operators.index_image=
 intersmash.wildfly.operators.package_manifest=eap

--- a/testsuite/integration-tests/eapxp5-global-test.properties
+++ b/testsuite/integration-tests/eapxp5-global-test.properties
@@ -13,8 +13,8 @@ xtf.junit.prebuilder.synchronized=true
 intersmash.mysql.image=registry.redhat.io/rhel10/mysql-84:latest
 intersmash.postgresql.image=registry.redhat.io/rhel8/postgresql-16:latest
 
-intersmash.wildfly.image=registry.redhat.io/jboss-eap-8/eap8-openjdk21-builder-openshift-rhel8:latest
-intersmash.wildfly.runtime.image=registry.redhat.io/jboss-eap-8/eap8-openjdk21-runtime-openshift-rhel8:latest
+intersmash.wildfly.image=registry.redhat.io/jboss-eap-8/eap8-openjdk17-builder-openshift-rhel8:latest
+intersmash.wildfly.runtime.image=registry.redhat.io/jboss-eap-8/eap8-openjdk17-runtime-openshift-rhel8:latest
 intersmash.wildfly.operators.catalog_source=redhat-operators
 intersmash.wildfly.operators.index_image=
 intersmash.wildfly.operators.package_manifest=eap
@@ -22,7 +22,7 @@ intersmash.wildfly.operators.channel=stable
 intersmash.wildfly.helm.charts.repo=https://github.com/jbossas/eap-charts.git
 intersmash.wildfly.helm.charts.branch=eap-xp5-1.0.0
 intersmash.wildfly.helm.charts.name=eap-xp5
-intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-21
+intersmash.bootable.jar.image=registry.access.redhat.com/ubi8/openjdk-17
 
 intersmash.eap7.image=registry.redhat.io/jboss-eap-7/eap74-openjdk17-openshift-rhel8:latest
 intersmash.eap7.runtime.image=registry.redhat.io/jboss-eap-7/eap74-openjdk17-runtime-openshift-rhel8:latest


### PR DESCRIPTION
## Description

Fixing the eap80-global.properties and eapxp5-gobal.properties files to use correct JBoss EAP 8.0 images

Resolves #306 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift
