### PR TITLE
[issue-323] - Fix OpenShiftAIOpenShiftOperatorProvisioner.removeSubscription

### DIFF
--- a/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftAIOpenShiftOperatorProvisioner.java
+++ b/provisioners/src/main/java/org/jboss/intersmash/provision/openshift/OpenShiftAIOpenShiftOperatorProvisioner.java
@@ -84,7 +84,7 @@ public class OpenShiftAIOpenShiftOperatorProvisioner
 
 	@Override
 	protected void removeSubscription() {
-		this.execute(this.getTargetNamespace(), "delete", "subscription", packageManifestName, "--ignore-not-found");
+		this.executeInNamespace(this.getTargetNamespace(), "delete", "subscription", packageManifestName, "--ignore-not-found");
 	}
 
 	// =================================================================================================================


### PR DESCRIPTION
## Description

Resolves #323

Fix `oc` command syntax in method OpenShiftAIOpenShiftOperatorProvisioner#removeSubscription;

<!--
Thank a lot for taking time to contribute to Intersmash <3!

Please provide a description of what your PR does, by providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
